### PR TITLE
fix: refresh entity-form when list config filter changes

### DIFF
--- a/src/components/entity-form/entity-form.ts
+++ b/src/components/entity-form/entity-form.ts
@@ -275,8 +275,8 @@ export class EntityForm extends ViewElement {
   get availableEntityConfigs(): EntityConfig[] {
     return this.state.entityConfigs.filter(
       config =>
-        this.state.listConfig.filter.includeTypes.length === 0 ||
-        this.state.listConfig.filter.includeTypes.includes(config.id),
+        this.state.listFilter.includeTypes.length === 0 ||
+        this.state.listFilter.includeTypes.includes(config.id),
     );
   }
 
@@ -297,16 +297,16 @@ export class EntityForm extends ViewElement {
     this.initialTags = JSON.stringify(this.tags);
 
     reaction(
-      () => appState.listConfig,
+      () => [appState.listConfigId, appState.listFilter],
       () => {
         if (this.entityId) {
           return;
         }
 
         this.tags =
-          this.state.listConfig.filter.tagging[ListFilterType.CONTAINS_ALL_OF];
+          this.state.listFilter.tagging[ListFilterType.CONTAINS_ALL_OF];
         this.published =
-          this.state.listConfig.setting[SettingName.AUTO_PUBLISH];
+          this.state.listSetting[SettingName.AUTO_PUBLISH];
 
         if (this.availableEntityConfigs.length === 1) {
           this.type = this.availableEntityConfigs[0].id;
@@ -655,8 +655,8 @@ export class EntityForm extends ViewElement {
     this.tagValue = '';
     if (!this.entityId) {
       this.tags =
-        this.state.listConfig.filter.tagging[ListFilterType.CONTAINS_ALL_OF];
-      this.published = this.state.listConfig.setting[SettingName.AUTO_PUBLISH];
+        this.state.listFilter.tagging[ListFilterType.CONTAINS_ALL_OF];
+      this.published = this.state.listSetting[SettingName.AUTO_PUBLISH];
     }
     this.state.setTagSuggestions([]);
 


### PR DESCRIPTION
Fixes #397

The "type" field in entity-form was not re-rendering when the active list config's filter was updated.

**Root cause:** The MobX reaction tracked `appState.listConfig` (derived from the `listConfigs` array), but filter changes only update `state.listFilter` — a separate observable that was never tracked. `availableEntityConfigs` also read from `state.listConfig.filter.includeTypes` (stale) instead of `state.listFilter.includeTypes` (live).

**Fix:** Updated the reaction to track `[appState.listConfigId, appState.listFilter]`, and changed all filter/setting reads in entity-form to use the live `state.listFilter` / `state.listSetting` observables.

Generated with [Claude Code](https://claude.ai/code)