### PR TITLE
fix: unpublished badge doesn't disappear after publishing

### DIFF
--- a/src/components/entity-form/entity-form.events.ts
+++ b/src/components/entity-form/entity-form.events.ts
@@ -6,6 +6,7 @@ export interface EntityItemUpdatedEventPayload {
   id: number;
   tags: string[];
   properties: EntityProperty[];
+  published: boolean;
 }
 
 export class EntityItemUpdatedEvent extends CustomEvent<EntityItemUpdatedEventPayload> {

--- a/src/components/entity-form/entity-form.ts
+++ b/src/components/entity-form/entity-form.ts
@@ -622,6 +622,7 @@ export class EntityForm extends ViewElement {
             id: this.entityId,
             tags: this.tags,
             properties: result.properties,
+            published: payload.published,
           }),
         );
 

--- a/src/components/entity-list/entity-list.ts
+++ b/src/components/entity-list/entity-list.ts
@@ -184,7 +184,7 @@ export class EntityList extends ViewElement {
   }
 
   private handleItemUpdated(e: EntityItemUpdatedEvent): void {
-    const { properties, tags } = e.detail;
+    const { properties, tags, published } = e.detail;
 
     const updatedList = this.state.listEntities.map(item =>
       item.id === e.detail.id
@@ -192,6 +192,7 @@ export class EntityList extends ViewElement {
             ...item,
             properties,
             tags,
+            published,
           }
         : item,
     );


### PR DESCRIPTION
Fixes #99

The `EntityItemUpdatedEvent` payload was missing `published`, so `handleItemUpdated` in `entity-list.ts` never updated the published field on the entity in state. The badge kept reading the stale `false` value even after saving.

Generated with [Claude Code](https://claude.ai/code)