### PR TITLE
feat: add user-dashboard-view and user-dashboard component

### DIFF
--- a/src/components/app-container/app-container.ts
+++ b/src/components/app-container/app-container.ts
@@ -7,7 +7,7 @@ import { storage } from '@/lib/Storage';
 import { appState } from '@/state';
 import { ViewElement } from '@/lib/ViewElement';
 import { api } from '@/lib/Api';
-import { setupRouter } from '@/lib/Router';
+import { navigate, setupRouter } from '@/lib/Router';
 import { themed } from '@/lib/Theme';
 import { Router } from '@/models/Router';
 import { routes } from '@/routes';
@@ -280,6 +280,7 @@ export class AppContainer extends MobxLitElement {
   private async handleUserLoggedIn(): Promise<void> {
     await this.restoreState();
     this.syncUserData();
+    navigate('/dashboard');
   }
 
   private async syncUserData(): Promise<void> {

--- a/src/components/user-dashboard/user-dashboard.ts
+++ b/src/components/user-dashboard/user-dashboard.ts
@@ -1,0 +1,59 @@
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { css, html, nothing, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import { appState } from '@/state';
+import { translate } from '@/lib/Localization';
+import { StorageSource } from '@/models/Storage';
+
+@customElement('user-dashboard')
+export class UserDashboard extends MobxLitElement {
+  private state = appState;
+
+  static styles = css`
+    .user-dashboard {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .welcome {
+      font-size: 1.5rem;
+    }
+
+    .links {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+  `;
+
+  private get isCloudStorage(): boolean {
+    return this.state.storageSource === StorageSource.CLOUD;
+  }
+
+  private get displayName(): string {
+    if (!this.state.user) {
+      return '';
+    }
+    const { firstName, lastName, username } = this.state.user;
+    const fullName = [firstName, lastName].filter(Boolean).join(' ');
+    return fullName || username;
+  }
+
+  render(): TemplateResult {
+    return html`
+      <div class="user-dashboard">
+        ${this.isCloudStorage && this.displayName
+          ? html`<p class="welcome">
+              ${translate('dashboard.welcome', { name: this.displayName })}
+            </p>`
+          : nothing}
+        <div class="links">
+          <a href="/access">${translate('dashboard.manageAccess')}</a>
+          <a href="/settings">${translate('settings')}</a>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/lib/data/localization/en.json
+++ b/src/lib/data/localization/en.json
@@ -299,5 +299,7 @@
   "settingsTab.user": "User",
   "settingsTab.system": "System",
   "deleteItemsInList": "Delete items in list",
-  "deleteListConfigTitle": "Delete List Configuration"
+  "deleteListConfigTitle": "Delete List Configuration",
+  "dashboard.welcome": "Welcome, {name}!",
+  "dashboard.manageAccess": "Manage Access Policies"
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -65,4 +65,10 @@ export const routes: Route[] = [
     action: async () =>
       await import('@/views/user-settings-view/user-settings-view'),
   },
+  {
+    path: '/dashboard',
+    component: 'user-dashboard-view',
+    action: async () =>
+      await import('@/views/user-dashboard-view/user-dashboard-view'),
+  },
 ];

--- a/src/views/user-dashboard-view/user-dashboard-view.ts
+++ b/src/views/user-dashboard-view/user-dashboard-view.ts
@@ -1,0 +1,32 @@
+import { css, html, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import '@/components/user-dashboard/user-dashboard';
+import '@/components/login-form/login-form';
+import '@/components/logged-in/logged-in';
+import '@/components/logged-out/logged-out';
+import '@/components/user-header/user-header';
+import { ViewElement } from '@/lib/ViewElement';
+
+@customElement('user-dashboard-view')
+export class UserDashboardView extends ViewElement {
+  static styles = [
+    css`
+      .view-content {
+        margin-top: 1rem;
+      }
+    `,
+  ];
+
+  render(): TemplateResult {
+    return html` <user-header></user-header>
+      <div class="view-content">
+        <logged-out
+          ><template><login-form></login-form></template
+        ></logged-out>
+        <logged-in
+          ><template><user-dashboard></user-dashboard></template
+        ></logged-in>
+      </div>`;
+  }
+}


### PR DESCRIPTION
Implements #75

Creates a user dashboard view and component with:
- Welcome message with user's name (when using cloud storage)
- Links to /access (Manage Access Policies) and /settings
- Redirect to /dashboard after successful login

Generated with [Claude Code](https://claude.ai/code)