### PR TITLE
fix: mobile edit button unresponsive in entity-action-bar

### DIFF
--- a/src/components/entity-list/entity-list-item/entity-list-item.ts
+++ b/src/components/entity-list/entity-list-item/entity-list-item.ts
@@ -499,16 +499,16 @@ export class EntityListItem extends MobxLitElement {
                       `
                     : nothing}
                 </div>
-                ${this.mode === EntityListItemMode.FULL
-                  ? html`
-                      <entity-action-bar
-                        ?suggestion=${this.suggestion}
-                        @entity-action-bar-add=${this.handleAddSuggestion}
-                        @entity-action-bar-edit=${this.handleEditRequested}
-                      ></entity-action-bar>
-                    `
-                  : nothing}
               </div>
+              ${this.mode === EntityListItemMode.FULL
+                ? html`
+                    <entity-action-bar
+                      ?suggestion=${this.suggestion}
+                      @entity-action-bar-add=${this.handleAddSuggestion}
+                      @entity-action-bar-edit=${this.handleEditRequested}
+                    ></entity-action-bar>
+                  `
+                : nothing}
             `}
       </div>
     `;


### PR DESCRIPTION
Fixes #103

The `entity-action-bar` was nested inside the div with `@touchend` handler. That handler calls `e.preventDefault()` for long-press detection, which suppresses the synthetic click event on mobile — making the edit button unresponsive on touch devices.

Moved `entity-action-bar` outside the touch-handler div so touch events from its buttons no longer bubble through the `preventDefault()` call.

Generated with [Claude Code](https://claude.ai/code)