### PR TITLE
feat: add ThemeType enum and update theme application logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,10 @@
         "api-spec": "github:SikoSoft/api-spec#1.78.0",
         "dompurify": "^3.3.1",
         "file-saver": "^2.0.5",
-        "immer": "^10.1.1",
         "jszip": "^3.10.1",
         "lit": "~3.1.3",
         "marked": "^17.0.1",
-        "mobx": "~6.12.3",
-        "uuid": "^14.0.0"
+        "mobx": "~6.12.3"
       },
       "devDependencies": {
         "@types/file-saver": "^2.0.7",
@@ -4053,16 +4051,6 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
-    },
-    "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",

--- a/src/components/page-container/page-container.test.ts
+++ b/src/components/page-container/page-container.test.ts
@@ -85,6 +85,13 @@ describe('page-container', () => {
       el.setListConfigThemes([ThemeName.DARK, ThemeName.TODO]);
       expect(el.themes).toEqual([ThemeName.DARK, ThemeName.TODO]);
     });
+
+    it('prepends the base theme when all listConfigThemes are partial (layout-only)', async () => {
+      const el = await mount();
+      el.setTheme(ThemeName.LIGHT);
+      el.setListConfigThemes([ThemeName.TODO]);
+      expect(el.themes).toEqual([ThemeName.LIGHT, ThemeName.TODO]);
+    });
   });
 
   describe('classes getter', () => {

--- a/src/components/page-container/page-container.ts
+++ b/src/components/page-container/page-container.ts
@@ -13,7 +13,7 @@ import {
   pageContainerProps,
 } from './page-container.models';
 import { reaction } from 'mobx';
-import { ThemeName, defaultTheme } from '@/models/Page';
+import { ThemeName, ThemeType, defaultTheme } from '@/models/Page';
 import { StorageItemKey } from '@/models/Storage';
 import { ThemesUpdatedEvent } from './page-container.events';
 import { translate } from '@/lib/Localization';
@@ -83,9 +83,19 @@ export class PageContainer extends MobxLitElement {
 
   @state()
   get themes(): string[] {
-    return this.listConfigThemes.length
-      ? Array.from(this.listConfigThemes)
-      : [this.theme];
+    if (!this.listConfigThemes.length) {
+      return [this.theme];
+    }
+
+    const totalTypeCount = Object.values(ThemeType).length;
+    const allPartial = this.listConfigThemes.every(themeName => {
+      const theme = themes[themeName as ThemeName];
+      return theme && theme.type.length < totalTypeCount;
+    });
+
+    return allPartial
+      ? [this.theme, ...this.listConfigThemes]
+      : Array.from(this.listConfigThemes);
   }
 
   @state()

--- a/src/components/page-container/page-container.ts
+++ b/src/components/page-container/page-container.ts
@@ -90,7 +90,7 @@ export class PageContainer extends MobxLitElement {
     const totalTypeCount = Object.values(ThemeType).length;
     const allPartial = this.listConfigThemes.every(themeName => {
       const theme = themes[themeName as ThemeName];
-      return theme && theme.type.length < totalTypeCount;
+      return theme && new Set(theme.type).size !== totalTypeCount;
     });
 
     return allPartial

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -19,8 +19,14 @@ export enum ThemeName {
 }
 export const defaultTheme: ThemeName = ThemeName.LIGHT;
 
+export enum ThemeType {
+  LAYOUT = 'layout',
+  COLOR = 'color',
+}
+
 export interface Theme {
   name: ThemeName;
   backgroundColor: CSSResult;
   sheet: CSSStyleSheet;
+  type: ThemeType[];
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,5 +1,5 @@
-import { Theme, ThemeName, ThemeType } from '@/models/Page';
 import { css, unsafeCSS } from 'lit';
+import { Theme, ThemeName, ThemeType } from '@/models/Page';
 
 export const themes: Record<ThemeName, Theme> = {
   [ThemeName.LIGHT]: {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,4 +1,4 @@
-import { Theme, ThemeName } from '@/models/Page';
+import { Theme, ThemeName, ThemeType } from '@/models/Page';
 import { css, unsafeCSS } from 'lit';
 
 export const themes: Record<ThemeName, Theme> = {
@@ -6,26 +6,31 @@ export const themes: Record<ThemeName, Theme> = {
     name: ThemeName.LIGHT,
     backgroundColor: css`#ededed`,
     sheet: new CSSStyleSheet(),
+    type: [ThemeType.LAYOUT, ThemeType.COLOR],
   },
   [ThemeName.DARK]: {
     name: ThemeName.DARK,
     backgroundColor: css`#12221a`,
     sheet: new CSSStyleSheet(),
+    type: [ThemeType.LAYOUT, ThemeType.COLOR],
   },
   [ThemeName.TODO]: {
     name: ThemeName.TODO,
     backgroundColor: css`#ffffff`,
     sheet: new CSSStyleSheet(),
+    type: [ThemeType.LAYOUT],
   },
   [ThemeName.XMAS]: {
     name: ThemeName.XMAS,
     backgroundColor: css`#bb0000`,
     sheet: new CSSStyleSheet(),
+    type: [ThemeType.LAYOUT, ThemeType.COLOR],
   },
   [ThemeName.CRAFTACULAR]: {
     name: ThemeName.CRAFTACULAR,
     backgroundColor: css`#3d5a1e`,
     sheet: new CSSStyleSheet(),
+    type: [ThemeType.LAYOUT, ThemeType.COLOR],
   },
 };
 


### PR DESCRIPTION
Closes #105

## Changes

- Add `ThemeType` enum (`LAYOUT`, `COLOR`) to Page models
- Add `type` property to `Theme` interface
- Set `TODO` theme as layout-only, all others as full (layout + color)
- Update `page-container` `themes` getter: partial list config themes now add to the active user/system theme instead of replacing it

Generated with [Claude Code](https://claude.ai/code)