### PR TITLE
feat: add Everything to list-config carousel and entity-list-filter

### DIFF
--- a/src/components/entity-list-filter/entity-list-filter.ts
+++ b/src/components/entity-list-filter/entity-list-filter.ts
@@ -1,0 +1,28 @@
+import { html, nothing, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+
+import { appState } from '@/state';
+import { EntityListLoadEvent } from '@/components/entity-list/entity-list.events';
+import { ListFilterUpdatedEvent } from '@/components/list-filter/list-filter.events';
+
+import '@/components/list-filter/list-filter';
+
+@customElement('entity-list-filter')
+export class EntityListFilter extends MobxLitElement {
+  private state = appState;
+
+  private handleFilterUpdated = (_e: ListFilterUpdatedEvent): void => {
+    this.dispatchEvent(new EntityListLoadEvent());
+  };
+
+  render(): TemplateResult {
+    if (this.state.listConfigId) {
+      return html`${nothing}`;
+    }
+
+    return html`<list-filter
+      @list-filter-updated=${this.handleFilterUpdated}
+    ></list-filter>`;
+  }
+}

--- a/src/components/list-config/list-config.ts
+++ b/src/components/list-config/list-config.ts
@@ -119,6 +119,16 @@ export class ListConfig extends MobxLitElement {
         }
       }
 
+      .everything-slide .name,
+      .everything-slide .name:hover {
+        ss-input::part(input) {
+          cursor: default;
+          border-color: transparent;
+          background-color: transparent;
+          pointer-events: none;
+        }
+      }
+
       .carousel-wrapper {
         padding: 1rem;
         position: relative;
@@ -500,31 +510,59 @@ export class ListConfig extends MobxLitElement {
   }
 
   sync(_reset = false): void {
-    if (!this.state.listConfig) {
+    if (!this[ListConfigProp.VIEW_ONLY] && !this.state.listConfigId) {
+      this.state.setTitle(translate('everything'));
+      this.id = '';
+      this.name = translate('everything');
+      this.navigationIndex = 0;
       return;
     }
 
-    this.state.setTitle(this.state.listConfig.name);
-    this.id = this.state.listConfig.id;
-    this.name = this.state.listConfig.name;
-    this.navigationIndex = this.state.listConfigs.findIndex(
-      config => config.id === this.id,
+    const config = this.state.listConfigs.find(
+      c => c.id === this.state.listConfigId,
     );
+    if (!config) {
+      return;
+    }
+
+    this.state.setTitle(config.name);
+    this.id = config.id;
+    this.name = config.name;
+    this.navigationIndex =
+      this.state.listConfigs.findIndex(c => c.id === this.id) +
+      (this[ListConfigProp.VIEW_ONLY] ? 0 : 1);
   }
 
   setListConfigId(listConfigId: string): void {
-    if (!this.state.listConfig) {
-      return;
-    }
     storage.saveActiveListConfigId(listConfigId);
     this.state.setListConfigId(listConfigId);
-    this.state.setTitle(this.state.listConfig.name);
-    this.id = this.state.listConfig.id;
-    this.name = this.state.listConfig.name;
     this.dispatchEvent(new ListConfigChangedEvent({ listConfigId }));
   }
 
   carouselSlideChanged(e: CarouselSlideChangedEvent): void {
+    if (!this[ListConfigProp.VIEW_ONLY]) {
+      if (e.detail.slideIndex === 0) {
+        if (this.state.listConfigId === '') {
+          return;
+        }
+        this.state.setEditListConfigMode(false);
+        this.state.setSelectListConfigMode(false);
+        this.navigationIndex = e.detail.navigationIndex;
+        this.setListConfigId('');
+        return;
+      }
+      const newListConfigId =
+        this.state.listConfigs[e.detail.slideIndex - 1]?.id;
+      if (!newListConfigId || newListConfigId === this.state.listConfigId) {
+        return;
+      }
+      this.state.setEditListConfigMode(false);
+      this.state.setSelectListConfigMode(false);
+      this.navigationIndex = e.detail.navigationIndex;
+      this.setListConfigId(newListConfigId);
+      return;
+    }
+
     const newListConfigId = this.state.listConfigs[e.detail.slideIndex]?.id;
     if (!newListConfigId || newListConfigId === this.state.listConfigId) {
       return;
@@ -544,13 +582,17 @@ export class ListConfig extends MobxLitElement {
   }
 
   private handleFilterUpdated(_e: ListFilterUpdatedEvent): void {
-    storage.updateListFilter(this.state.listConfigId, this.state.listFilter);
+    if (this.state.listConfigId) {
+      storage.updateListFilter(this.state.listConfigId, this.state.listFilter);
+    }
     this.filterIsOpen = false;
     this.dispatchEvent(new EntityListLoadEvent());
   }
 
   private handleSortUpdated(_e: ListSortUpdatedEvent): void {
-    storage.updateListSort(this.state.listConfigId, this.state.listSort);
+    if (this.state.listConfigId) {
+      storage.updateListSort(this.state.listConfigId, this.state.listSort);
+    }
     this.sortIsOpen = false;
     this.dispatchEvent(new EntityListSyncEvent());
   }
@@ -611,11 +653,22 @@ export class ListConfig extends MobxLitElement {
           @carousel-slide-changed=${this.carouselSlideChanged}
         >
           ${this.ready
-            ? repeat(
-                this.state.listConfigs,
-                config => config.id,
-                config =>
-                  html`<div class="config-slide">
+            ? html`
+                ${!this[ListConfigProp.VIEW_ONLY]
+                  ? html`<div class="config-slide everything-slide">
+                      <div class="name">
+                        <ss-input
+                          type=${InputType.TEXT}
+                          value=${translate('everything')}
+                        ></ss-input>
+                      </div>
+                    </div>`
+                  : nothing}
+                ${repeat(
+                  this.state.listConfigs,
+                  config => config.id,
+                  config =>
+                    html`<div class="config-slide">
                     <div
                       class="close"
                       @click=${(e: MouseEvent): void => {
@@ -676,7 +729,8 @@ export class ListConfig extends MobxLitElement {
                       </div>
                     </div>
                   </div>`,
-              )
+                )}
+              `
             : nothing}
 
           <style>

--- a/src/views/list-view/list-view.ts
+++ b/src/views/list-view/list-view.ts
@@ -1,9 +1,8 @@
 import { css, html, nothing, TemplateResult } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 
-import { SettingName } from 'api-spec/models/Setting';
-
 import '@/components/entity-list/entity-list';
+import '@/components/entity-list-filter/entity-list-filter';
 import '@/components/list-config/list-config';
 import '@/components/public-entity-list/public-entity-list';
 import '@/components/user-header/user-header';
@@ -11,7 +10,7 @@ import '@/components/bulk-manager/bulk-manager';
 
 import { appState } from '@/state';
 import { storage } from '@/lib/Storage';
-import { navigate, routerState } from '@/lib/Router';
+import { routerState } from '@/lib/Router';
 import { ViewElement } from '@/lib/ViewElement';
 import { EntityList } from '@/components/entity-list/entity-list';
 import { PublicEntityList } from '@/components/public-entity-list/public-entity-list';
@@ -76,17 +75,9 @@ export class ListView extends ViewElement {
     const id = routerState.params['id'] || '';
 
     if (!id) {
-      const defaultId = this.appState.getSetting<string>(
-        SettingName.DEFAULT_LIST_CONFIG,
-      );
-      const defaultConfig =
-        defaultId && this.appState.listConfigs.find(c => c.id === defaultId);
-      const targetId = defaultConfig
-        ? defaultConfig.id
-        : this.appState.listConfigs[0]?.id;
-
-      if (targetId) {
-        navigate('/list/' + targetId);
+      if (this.appState.listConfigId !== '') {
+        this.appState.setListConfigId('');
+        storage.saveActiveListConfigId('');
       }
       return;
     }
@@ -112,6 +103,7 @@ export class ListView extends ViewElement {
       <user-header></user-header>
       <bulk-manager></bulk-manager>
       <div class="view-content">
+        <entity-list-filter></entity-list-filter>
         <entity-list></entity-list>
       </div>
     `;


### PR DESCRIPTION
Implements #107: Add "Everything" to list-config carousel

## Changes

- New `entity-list-filter` component that shows `list-filter` when no specific list config is active
- "Everything" slide added at carousel index 0 for authenticated users (non-editable)
- Removed navigation fallback in list-view: /list (no id) now renders in Everything mode
- Filter updates in Everything mode update state only (no storage save) while still refetching entities

Closes #107

Generated with [Claude Code](https://claude.ai/code)