### PR TITLE
fix: redirect to / on logout from floating-widget

### DIFF
--- a/src/components/user-pane/user-pane.ts
+++ b/src/components/user-pane/user-pane.ts
@@ -4,6 +4,7 @@ import { customElement, state } from 'lit/decorators.js';
 
 import { translate } from '@/lib/Localization';
 import { performLogout } from '@/lib/Auth';
+import { navigate } from '@/lib/Router';
 
 import { UserLoggedOutEvent } from '@/events/user-logged-out';
 
@@ -29,6 +30,7 @@ export class UserPane extends MobxLitElement {
     const success = await performLogout();
     if (success) {
       this.dispatchEvent(new UserLoggedOutEvent({}));
+      navigate('/');
     }
   }
 


### PR DESCRIPTION
Fix logout bug while on list view by adding `navigate('/')` to the `user-pane` logout handler, making it match the behavior of the logout route.

Closes #112

Generated with [Claude Code](https://claude.ai/code)