### PR TITLE
feat: add /debug route and move push-notification there

### DIFF
--- a/src/components/user-dashboard/user-dashboard.ts
+++ b/src/components/user-dashboard/user-dashboard.ts
@@ -6,8 +6,6 @@ import { appState } from '@/state';
 import { translate } from '@/lib/Localization';
 import { StorageSource } from '@/models/Storage';
 
-import '@/components/push-notification/push-notification';
-
 @customElement('user-dashboard')
 export class UserDashboard extends MobxLitElement {
   private state = appState;
@@ -55,7 +53,6 @@ export class UserDashboard extends MobxLitElement {
           <a href="access">${translate('dashboard.manageAccess')}</a>
           <a href="settings">${translate('settings')}</a>
         </div>
-        <push-notification></push-notification>
       </div>
     `;
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -80,4 +80,9 @@ export const routes: Route[] = [
     component: 'logout-view',
     action: async () => await import('@/views/logout-view/logout-view'),
   },
+  {
+    path: '/debug',
+    component: 'debug-view',
+    action: async () => await import('@/views/debug-view/debug-view'),
+  },
 ];

--- a/src/views/debug-view/debug-view.ts
+++ b/src/views/debug-view/debug-view.ts
@@ -1,0 +1,16 @@
+import { html, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import '@/components/push-notification/push-notification';
+import '@/components/user-header/user-header';
+import { ViewElement } from '@/lib/ViewElement';
+
+@customElement('debug-view')
+export class DebugView extends ViewElement {
+  render(): TemplateResult {
+    return html`
+      <user-header></user-header>
+      <push-notification></push-notification>
+    `;
+  }
+}


### PR DESCRIPTION
Creates new `debug-view` component at `/debug` route and moves `push-notification` rendering from `user-dashboard` into the new view.

Closes #114

Generated with [Claude Code](https://claude.ai/code)