### PR TITLE
fix: edit button in action bar no longer works on mobile

### DIFF
--- a/src/components/entity-list/entity-list-item/entity-list-item.ts
+++ b/src/components/entity-list/entity-list-item/entity-list-item.ts
@@ -358,8 +358,17 @@ export class EntityListItem extends MobxLitElement {
     return false;
   }
 
+  private isEventFromActionBar(e: Event): boolean {
+    return e.composedPath().some(
+      el => el instanceof HTMLElement && el.classList.contains('action-bar-container'),
+    );
+  }
+
   private handleTouchStart(e: TouchEvent): void {
     if (this.mode === EntityListItemMode.EDIT) {
+      return;
+    }
+    if (this.isEventFromActionBar(e)) {
       return;
     }
     this.touchStartX = e.touches[0].clientX;
@@ -383,6 +392,9 @@ export class EntityListItem extends MobxLitElement {
     if (this.mode === EntityListItemMode.EDIT) {
       return;
     }
+    if (this.isEventFromActionBar(e)) {
+      return;
+    }
     const dx = e.touches[0].clientX - this.touchStartX;
     const dy = e.touches[0].clientY - this.touchStartY;
     if (Math.abs(dx) > 10 || Math.abs(dy) > 10) {
@@ -396,6 +408,9 @@ export class EntityListItem extends MobxLitElement {
 
   private handleTouchEnd(e: TouchEvent): void {
     if (this.mode === EntityListItemMode.EDIT) {
+      return;
+    }
+    if (this.isEventFromActionBar(e)) {
       return;
     }
     e.preventDefault();


### PR DESCRIPTION
Fixes #124

Calls to `e.preventDefault()` in `handleTouchEnd` were unconditionally blocking the browser from generating synthetic click events, so the Edit/Delete/Add buttons in `entity-action-bar` never fired on mobile.

Added `isEventFromActionBar()` which checks `composedPath()` for the `action-bar-container` element, and early-returns from all three touch handlers when the event originates from the action bar. This lets button clicks propagate normally while preserving hold-to-activate multiselect on the entity body.

Generated with [Claude Code](https://claude.ai/code)