### PR TITLE
feat: add account-view and account card to user dashboard

### DIFF
--- a/src/components/svg-icon/svg/svg-profile.ts
+++ b/src/components/svg-icon/svg/svg-profile.ts
@@ -1,0 +1,14 @@
+import { LitElement, TemplateResult, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('svg-profile')
+export class SVGProfile extends LitElement {
+  render(): TemplateResult {
+    return html`
+      <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="12" cy="8" r="4" stroke="currentColor"></circle>
+        <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" stroke="currentColor"></path>
+      </svg>
+    `;
+  }
+}

--- a/src/components/user-dashboard/user-dashboard.ts
+++ b/src/components/user-dashboard/user-dashboard.ts
@@ -3,6 +3,7 @@ import { css, html, nothing, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type { ChartData, ChartOptions } from 'chart.js';
 
+import '@/components/svg-icon/svg/svg-profile';
 import '@/components/svg-icon/svg/svg-key';
 import '@/components/svg-icon/svg/svg-settings';
 import '@/components/svg-icon/svg/svg-database';
@@ -74,6 +75,7 @@ export class UserDashboard extends MobxLitElement {
       border-color: var(--primary-color, #0066ff);
     }
 
+    .card svg-profile,
     .card svg-key,
     .card svg-settings,
     .card svg-database,
@@ -194,6 +196,11 @@ export class UserDashboard extends MobxLitElement {
             </p>`
           : nothing}
         <div class="cards">
+          <a href="account" class="card">
+            <svg-profile></svg-profile>
+            <span class="card-label">${translate('account')}</span>
+          </a>
+
           <a href="access" class="card">
             <svg-key></svg-key>
             <span class="card-label">${translate('access')}</span>

--- a/src/lib/data/localization/en.json
+++ b/src/lib/data/localization/en.json
@@ -335,5 +335,6 @@
   "pushNotification.failed": "Failed to send notification.",
   "pushNotification.titleBodyRequired": "Title and body are required.",
   "dashboard.activityChart": "Activity by Month",
-  "dashboard.categoryChart": "Category Breakdown"
+  "dashboard.categoryChart": "Category Breakdown",
+  "account": "Account"
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -50,8 +50,8 @@ export const routes: Route[] = [
   },
   {
     path: '/account',
-    component: 'account-form',
-    action: async () => await import('@/components/account-form/account-form'),
+    component: 'account-view',
+    action: async () => await import('@/views/account-view/account-view'),
   },
   {
     path: '/wizard',

--- a/src/views/account-view/account-view.ts
+++ b/src/views/account-view/account-view.ts
@@ -1,0 +1,29 @@
+import { css, html, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import '@/components/account-form/account-form';
+import '@/components/logged-in/logged-in';
+import '@/components/user-header/user-header';
+import { ViewElement } from '@/lib/ViewElement';
+import { themed } from '@/lib/Theme';
+
+@themed()
+@customElement('account-view')
+export class AccountView extends ViewElement {
+  static styles = css`
+    .view-content {
+      margin-top: 1rem;
+    }
+  `;
+
+  render(): TemplateResult {
+    return html`
+      <logged-in>
+        <template><user-header></user-header></template>
+      </logged-in>
+      <div class="view-content">
+        <account-form></account-form>
+      </div>
+    `;
+  }
+}


### PR DESCRIPTION
Implements #127: Add user account form to home page

- Creates `account-view` component that renders `user-header` (logged-in only) and `account-form` for all users
- Creates `svg-profile` icon for use in dashboard cards
- Updates /account route to use `account-view` instead of `account-form` directly
- Adds account card at top of user-dashboard card links with profile icon
- Adds 'account' localization key

Closes #127

Generated with [Claude Code](https://claude.ai/code)