### PR TITLE
feat: add password card to user-dashboard

### DIFF
--- a/src/components/svg-icon/svg/svg-lock.ts
+++ b/src/components/svg-icon/svg/svg-lock.ts
@@ -1,0 +1,15 @@
+import { LitElement, TemplateResult, html } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('svg-lock')
+export class SVGLock extends LitElement {
+  render(): TemplateResult {
+    return html`
+      <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+        <rect x="5" y="11" width="14" height="10" rx="2" stroke="currentColor"></rect>
+        <path d="M8 11V7a4 4 0 0 1 8 0v4" stroke="currentColor"></path>
+        <circle cx="12" cy="16" r="1.5" fill="currentColor" stroke="none"></circle>
+      </svg>
+    `;
+  }
+}

--- a/src/components/user-dashboard/user-dashboard.ts
+++ b/src/components/user-dashboard/user-dashboard.ts
@@ -5,6 +5,7 @@ import type { ChartData, ChartOptions } from 'chart.js';
 
 import '@/components/svg-icon/svg/svg-profile';
 import '@/components/svg-icon/svg/svg-key';
+import '@/components/svg-icon/svg/svg-lock';
 import '@/components/svg-icon/svg/svg-settings';
 import '@/components/svg-icon/svg/svg-database';
 import '@/components/svg-icon/svg/svg-layers';
@@ -77,6 +78,7 @@ export class UserDashboard extends MobxLitElement {
 
     .card svg-profile,
     .card svg-key,
+    .card svg-lock,
     .card svg-settings,
     .card svg-database,
     .card svg-layers {
@@ -199,6 +201,11 @@ export class UserDashboard extends MobxLitElement {
           <a href="account" class="card">
             <svg-profile></svg-profile>
             <span class="card-label">${translate('account')}</span>
+          </a>
+
+          <a href="password" class="card">
+            <svg-lock></svg-lock>
+            <span class="card-label">${translate('password')}</span>
           </a>
 
           <a href="access" class="card">


### PR DESCRIPTION
Adds a password card linking to /password right after the account card in user-dashboard. Creates a new svg-lock icon component for the card.

Closes #128

Generated with [Claude Code](https://claude.ai/code)