### PR TITLE
fix: add spacing and padding to access policies view

### DIFF
--- a/src/components/access-policy-group-list/access-policy-group-list.ts
+++ b/src/components/access-policy-group-list/access-policy-group-list.ts
@@ -22,6 +22,7 @@ export class AccessPolicyGroupList extends MobxLitElement {
       display: flex;
       flex-direction: column;
       gap: 1rem;
+      padding: 1rem;
     }
 
     .groups-list {

--- a/src/components/access-policy-list/access-policy-list.ts
+++ b/src/components/access-policy-list/access-policy-list.ts
@@ -26,6 +26,7 @@ export class AccessPolicyList extends MobxLitElement {
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
+      padding: 1rem;
     }
 
     .no-policies {

--- a/src/views/access-policies-view/access-policies-view.ts
+++ b/src/views/access-policies-view/access-policies-view.ts
@@ -15,6 +15,9 @@ export class AccessPoliciesView extends ViewElement {
     css`
       .view-content {
         margin-top: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
       }
     `,
   ];


### PR DESCRIPTION
Fixes spacing issues in the /access route:

- Add 1rem gap between access policies & access groups sections
- Add 1rem padding to both boxes so content is not flush with the box edge

Closes #132

Generated with [Claude Code](https://claude.ai/code)