### PR TITLE
fix: reset floating-widget to closed state on login

### DIFF
--- a/src/components/app-container/app-container.ts
+++ b/src/components/app-container/app-container.ts
@@ -299,6 +299,7 @@ export class AppContainer extends MobxLitElement {
   }
 
   private async handleUserLoggedIn(): Promise<void> {
+    this.state.setWidgetIsOpen(false);
     await this.restoreState();
     this.syncUserData();
     navigate('/');


### PR DESCRIPTION
Fixes #135

Ensure `widgetIsOpen` is always reset to `false` when a user logs in, preventing the floating-widget from appearing open on a fresh session if it was open when the user previously logged out.

Generated with [Claude Code](https://claude.ai/code)