### PR TITLE
fix: remove excess spacing between markdown list items

### DIFF
--- a/src/components/entity-list/entity-list-item/entity-list-item.ts
+++ b/src/components/entity-list/entity-list-item/entity-list-item.ts
@@ -182,6 +182,15 @@ export class EntityListItem extends MobxLitElement {
 
     .property-longtext .property-value {
       white-space: pre-wrap;
+
+      ul,
+      ol {
+        margin: 0;
+
+        li p {
+          margin: 0;
+        }
+      }
     }
 
     .unpublished-badge {


### PR DESCRIPTION
Removes extra space between bullet points rendered from markdown in entity-list-item.

When `marked` parses loose markdown lists (items separated by blank lines), it wraps each `<li>` in a `<p>` tag. Browser default margins on those `<p>` tags caused the large gaps. Reset margins on ul/ol and li > p inside .property-longtext .property-value.

Closes #137

Generated with [Claude Code](https://claude.ai/code)