### PR TITLE
fix: restore touch scrolling in list-config collapsibles

### DIFF
--- a/src/components/list-config/list-config.ts
+++ b/src/components/list-config/list-config.ts
@@ -59,7 +59,6 @@ export class ListConfig extends MobxLitElement {
     :host {
       display: block;
       width: 100%;
-      touch-action: none;
     }
 
     .list-config {
@@ -132,6 +131,7 @@ export class ListConfig extends MobxLitElement {
       .carousel-wrapper {
         padding: 1rem;
         position: relative;
+        touch-action: none;
       }
 
       .collapsable-menus {


### PR DESCRIPTION
Move touch-action: none from :host to .carousel-wrapper so vertical scroll is no longer blocked within the Access, Settings, Filter, and Sort collapsibles on mobile. The carousel still captures horizontal swipes via its own touch-action scope.

Fixes #144

Generated with [Claude Code](https://claude.ai/code)