### PR TITLE
feat: scroll long-text-field to top of viewport on focus

### DIFF
--- a/src/components/entity-form/long-text-field/long-text-field.ts
+++ b/src/components/entity-form/long-text-field/long-text-field.ts
@@ -61,6 +61,10 @@ export class LongTextField extends LitElement {
   @query('textarea')
   textareaElement: HTMLTextAreaElement | undefined;
 
+  protected handleFocus(): void {
+    this.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
   protected handleInputChanged(): void {
     if (!this.textareaElement) {
       return;
@@ -87,6 +91,7 @@ export class LongTextField extends LitElement {
   render(): TemplateResult {
     return html`
       <textarea
+        @focus=${this.handleFocus}
         @input=${this.handleInputChanged}
         .value=${this[LongTextFieldProp.VALUE]}
       ></textarea>


### PR DESCRIPTION
When a long-text-field is focused, the viewport smoothly scrolls to put the textfield at the top.

Added a `handleFocus` method to `long-text-field.ts` that calls `scrollIntoView` with smooth behavior, triggered on the textarea's focus event.

Closes #143

Generated with [Claude Code](https://claude.ai/code)