### PR TITLE
fix: suppress browser window for 'add' action in push notification service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -51,6 +51,15 @@ self.addEventListener('push', event => {
 self.addEventListener('notificationclick', event => {
   event.notification.close();
   const actionUrls = event.notification.data?.actionUrls ?? {};
+
+  if (event.action === 'add') {
+    const url = actionUrls[event.action];
+    if (url) {
+      event.waitUntil(fetch(url));
+    }
+    return;
+  }
+
   const url = event.action ? actionUrls[event.action] : '/';
   event.waitUntil(
     clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clientList => {


### PR DESCRIPTION
When the 'add' action button is clicked in a push notification, call the API URL via a background fetch instead of opening a browser window.

Closes #142

Generated with [Claude Code](https://claude.ai/code)