### PR TITLE
refactor: remove state/storage handling from list-filter

### DIFF
--- a/src/components/entity-list-customizer/entity-list-customizer.ts
+++ b/src/components/entity-list-customizer/entity-list-customizer.ts
@@ -4,6 +4,9 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 
 import { appState } from '@/state';
 import { translate } from '@/lib/Localization';
+import { storage } from '@/lib/Storage';
+import { addToast } from '@/lib/Util';
+import { NotificationType } from '@ss/ui/components/notification-provider.models';
 import { EntityListLoadEvent } from '@/components/entity-list/entity-list.events';
 import { ListFilterUpdatedEvent } from '@/components/list-filter/list-filter.events';
 import { ListSortUpdatedEvent } from '@/components/list-sort/list-sort.events';
@@ -42,7 +45,10 @@ export class EntityListCustomizer extends MobxLitElement {
     `,
   ];
 
-  private handleFilterUpdated = (_e: ListFilterUpdatedEvent): void => {
+  private handleFilterUpdated = (e: ListFilterUpdatedEvent): void => {
+    this.state.setListFilter(e.detail);
+    storage.saveActiveFilter(e.detail);
+    addToast(translate('filterUpdated'), NotificationType.INFO);
     this.dispatchEvent(new EntityListLoadEvent());
   };
 

--- a/src/components/list-config/list-config.ts
+++ b/src/components/list-config/list-config.ts
@@ -581,10 +581,12 @@ export class ListConfig extends MobxLitElement {
     this.themeManagerIsOpen = false;
   }
 
-  private handleFilterUpdated(_e: ListFilterUpdatedEvent): void {
+  private handleFilterUpdated(e: ListFilterUpdatedEvent): void {
+    this.state.setListFilter(e.detail);
     if (this.state.listConfigId) {
-      storage.updateListFilter(this.state.listConfigId, this.state.listFilter);
+      storage.updateListFilter(this.state.listConfigId, e.detail);
     }
+    addToast(translate('filterUpdated'), NotificationType.INFO);
     this.filterIsOpen = false;
     this.dispatchEvent(new EntityListLoadEvent());
   }

--- a/src/components/list-filter/list-filter.events.ts
+++ b/src/components/list-filter/list-filter.events.ts
@@ -1,6 +1,13 @@
+import { ListFilter as ListFilterModel } from 'api-spec/models/List';
+
+export interface ExtendedListFilter extends ListFilterModel {
+  published?: boolean;
+  suggestion?: boolean;
+}
+
 export const listFilterUpdatedEventName = 'list-filter-updated';
 
-export type ListFilterUpdatedEventPayload = Record<never, unknown>;
+export type ListFilterUpdatedEventPayload = ExtendedListFilter;
 
 export class ListFilterUpdatedEvent extends CustomEvent<ListFilterUpdatedEventPayload> {
   constructor(payload: ListFilterUpdatedEventPayload) {

--- a/src/components/list-filter/list-filter.ts
+++ b/src/components/list-filter/list-filter.ts
@@ -7,28 +7,21 @@ import { reaction } from 'mobx';
 
 import {
   ListFilterType,
-  ListFilter as ListFilterModel,
   ListFilterTimeType,
   TimeContext,
   TextContext,
   FilterProperty,
 } from 'api-spec/models/List';
 
-interface ExtendedListFilter extends ListFilterModel {
-  published?: boolean;
-  suggestion?: boolean;
-}
 import { translate } from '@/lib/Localization';
 
 import { appState } from '@/state';
 import { SavedListFilter, storage } from '@/lib/Storage';
-import { addToast } from '@/lib/Util';
-import { NotificationType } from '@ss/ui/components/notification-provider.models';
 import { SettingName, TagSuggestions } from 'api-spec/models/Setting';
 
 import { TimeFiltersUpdatedEvent } from '@/components/list-filter/time-filters/time-filters.events';
 import { FilterPropertiesUpdatedEvent } from '@/components/list-filter/filter-properties/filter-properties.events';
-import { ListFilterUpdatedEvent } from './list-filter.events';
+import { ExtendedListFilter, ListFilterUpdatedEvent } from './list-filter.events';
 import { TagsUpdatedEvent } from '@ss/ui/components/tag-manager.events';
 import { TagSuggestionsRequestedEvent } from '@ss/ui/components/tag-input.events';
 import { OptionSelectorChangedEvent } from '@/components/option-selector/option-selector.events';
@@ -205,11 +198,7 @@ export class ListFilter extends MobxLitElement {
   }
 
   private handleUpdateClick(_e: CustomEvent): void {
-    this.state.setListFilter(this.filter);
-    storage.saveActiveFilter(this.state.listFilter);
-
-    this.dispatchEvent(new ListFilterUpdatedEvent({}));
-    addToast(translate('filterUpdated'), NotificationType.INFO);
+    this.dispatchEvent(new ListFilterUpdatedEvent(this.filter));
   }
 
   private handleTimeChanged(e: TimeFiltersUpdatedEvent): void {


### PR DESCRIPTION
Closes #140

The `list-filter` component now only broadcasts `ListFilterUpdatedEvent` with the filter as payload. Callers are responsible for updating appState, persisting to storage, and showing the toast notification.

Generated with [Claude Code](https://claude.ai/code)