### PR TITLE
feat: update filter settings in medal config form (issue #150)

### DIFF
--- a/src/components/list-filter/list-filter.models.ts
+++ b/src/components/list-filter/list-filter.models.ts
@@ -1,0 +1,19 @@
+import { ControlType } from '@/models/Control';
+import { PropConfigMap, PropTypes } from '@/models/Prop';
+import { ListFilter as ListFilterSpec } from 'api-spec/models/List';
+
+export enum ListFilterProp {
+  EXTERNAL_FILTER = 'externalFilter',
+}
+
+export interface ListFilterProps extends PropTypes {
+  [ListFilterProp.EXTERNAL_FILTER]: ListFilterSpec | undefined;
+}
+
+export const listFilterProps: PropConfigMap<ListFilterProps> = {
+  [ListFilterProp.EXTERNAL_FILTER]: {
+    default: undefined,
+    control: { type: ControlType.HIDDEN },
+    description: 'Optional external filter used instead of the app state filter',
+  },
+};

--- a/src/components/list-filter/list-filter.ts
+++ b/src/components/list-filter/list-filter.ts
@@ -1,5 +1,5 @@
-import { html, css, TemplateResult } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { html, css, PropertyValues, TemplateResult } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -74,6 +74,8 @@ export class ListFilter extends MobxLitElement {
       pointer-events: initial;
     }
   `;
+
+  @property({ type: Object }) externalFilter?: ListFilterSpec;
 
   @state() [ListFilterType.CONTAINS_ONE_OF]: string[] = [];
   @state() [ListFilterType.CONTAINS_ALL_OF]: string[] = [];
@@ -164,8 +166,14 @@ export class ListFilter extends MobxLitElement {
     this.savedFilters = storage.getSavedFilters();
   }
 
+  updated(changedProperties: PropertyValues): void {
+    if (changedProperties.has('externalFilter') && this.externalFilter !== undefined) {
+      this.sync();
+    }
+  }
+
   sync(_reset: boolean = false): void {
-    const listFilter = this.state.listFilter as ListFilterSpec;
+    const listFilter = (this.externalFilter ?? this.state.listFilter) as ListFilterSpec;
     Object.values(ListFilterType).forEach(type => {
       this[type] = listFilter.tagging?.[type] ?? [];
     });

--- a/src/components/list-filter/list-filter.ts
+++ b/src/components/list-filter/list-filter.ts
@@ -13,6 +13,11 @@ import {
   TextContext,
   FilterProperty,
 } from 'api-spec/models/List';
+import {
+  ListFilterProp,
+  listFilterProps,
+  ListFilterProps,
+} from './list-filter.models';
 
 import { translate } from '@/lib/Localization';
 
@@ -75,7 +80,9 @@ export class ListFilter extends MobxLitElement {
     }
   `;
 
-  @property({ type: Object }) externalFilter?: ListFilterSpec;
+  @property({ type: Object })
+  [ListFilterProp.EXTERNAL_FILTER]: ListFilterProps[ListFilterProp.EXTERNAL_FILTER] =
+    listFilterProps[ListFilterProp.EXTERNAL_FILTER].default;
 
   @state() [ListFilterType.CONTAINS_ONE_OF]: string[] = [];
   @state() [ListFilterType.CONTAINS_ALL_OF]: string[] = [];

--- a/src/components/list-filter/list-filter.ts
+++ b/src/components/list-filter/list-filter.ts
@@ -174,7 +174,7 @@ export class ListFilter extends MobxLitElement {
   }
 
   updated(changedProperties: PropertyValues): void {
-    if (changedProperties.has('externalFilter') && this.externalFilter !== undefined) {
+    if (changedProperties.has(ListFilterProp.EXTERNAL_FILTER)) {
       this.sync();
     }
   }

--- a/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
+++ b/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
@@ -1,5 +1,5 @@
 import { html, css, nothing, TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
 import {
@@ -9,12 +9,11 @@ import {
   UniqueTagCountFactContext,
   MedalCountFactContext,
 } from 'api-spec/models/Medal';
-import { ListFilterTimeType, TimeContext, defaultListFilter } from 'api-spec/models/List';
+import { defaultListFilter } from 'api-spec/models/List';
 
 import { translate } from '@/lib/Localization';
 import { SelectChangedEvent } from '@ss/ui/components/ss-select.events';
 import { InputChangedEvent } from '@ss/ui/components/ss-input.events';
-import { ToggleChangedEvent } from '@ss/ui/components/ss-toggle.events';
 import { themed } from '@/lib/Theme';
 
 import {
@@ -23,22 +22,18 @@ import {
   FactRequestEditorProps,
 } from './fact-request-editor.models';
 import { FactRequestChangedEvent, FactRequestRemovedEvent } from './fact-request-editor.events';
+import { ListFilterUpdatedEvent } from '@/components/list-filter/list-filter.events';
 
 import '@ss/ui/components/ss-input';
 import '@ss/ui/components/ss-select';
-import '@ss/ui/components/ss-toggle';
 import '@ss/ui/components/ss-button';
+import '@ss/ui/components/pop-up';
+import '@/components/list-filter/list-filter';
 
 const operationOptions = [
   { value: FactOperation.ENTITY_COUNT, label: 'Entity Count' },
   { value: FactOperation.UNIQUE_TAG_COUNT, label: 'Unique Tag Count' },
   { value: FactOperation.MEDAL_COUNT, label: 'Medal Count' },
-];
-
-const timeTypeOptions = [
-  { value: ListFilterTimeType.ALL_TIME, label: 'All Time' },
-  { value: ListFilterTimeType.EXACT_DATE, label: 'Exact Date' },
-  { value: ListFilterTimeType.RANGE, label: 'Date Range' },
 ];
 
 @themed()
@@ -74,34 +69,6 @@ export class FactRequestEditor extends MobxLitElement {
       font-weight: bold;
     }
 
-    .field input[type='date'] {
-      padding: 0.375rem 0.5rem;
-      border: 1px solid var(--color-border, #ccc);
-      border-radius: 4px;
-      font-size: 0.875rem;
-      box-sizing: border-box;
-      width: 100%;
-    }
-
-    .toggle-row {
-      display: flex;
-      gap: 1.5rem;
-      align-items: center;
-      margin-bottom: 0.75rem;
-      flex-wrap: wrap;
-    }
-
-    .toggle-item {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-
-    .toggle-item label {
-      font-size: 0.8125rem;
-      font-weight: bold;
-    }
-
     .context-fields {
       border-top: 1px solid var(--color-border, #eee);
       padding-top: 0.75rem;
@@ -114,6 +81,13 @@ export class FactRequestEditor extends MobxLitElement {
       margin-bottom: 0.5rem;
       opacity: 0.7;
     }
+
+    .filter-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
   `;
 
   @property({ type: Object })
@@ -124,6 +98,8 @@ export class FactRequestEditor extends MobxLitElement {
   [FactRequestEditorProp.INDEX]: FactRequestEditorProps[FactRequestEditorProp.INDEX] =
     factRequestEditorProps[FactRequestEditorProp.INDEX].default;
 
+  @state() private filterPopupOpen: boolean = false;
+
   private emit(factRequest: FactRequest): void {
     this.dispatchEvent(
       new FactRequestChangedEvent({
@@ -133,137 +109,45 @@ export class FactRequestEditor extends MobxLitElement {
     );
   }
 
-  private renderFilterFields(
+  private handleFilterUpdated(
+    e: ListFilterUpdatedEvent,
+    context: EntityCountFactContext | UniqueTagCountFactContext,
+    fr: FactRequest,
+  ): void {
+    this.emit({ ...fr, context: { ...context, filter: e.detail } });
+    this.filterPopupOpen = false;
+  }
+
+  private renderFilterButton(
     context: EntityCountFactContext | UniqueTagCountFactContext,
     fr: FactRequest,
   ): TemplateResult {
-    const { filter } = context;
-    const timeType = (filter.time ?? { type: ListFilterTimeType.ALL_TIME }).type;
-
     return html`
       <div class="context-fields">
         <div class="section-label">${translate('filterSettings')}</div>
-        <div class="toggle-row">
-          <div class="toggle-item">
-            <label>${translate('includeAll')}</label>
-            <ss-toggle
-              ?on=${filter.includeAll}
-              @toggle-changed=${(e: ToggleChangedEvent): void => {
-                this.emit({
-                  ...fr,
-                  context: { ...context, filter: { ...filter, includeAll: e.detail.on } },
-                });
-              }}
-            ></ss-toggle>
-          </div>
-          <div class="toggle-item">
-            <label>${translate('includeUntagged')}</label>
-            <ss-toggle
-              ?on=${filter.includeUntagged}
-              @toggle-changed=${(e: ToggleChangedEvent): void => {
-                this.emit({
-                  ...fr,
-                  context: { ...context, filter: { ...filter, includeUntagged: e.detail.on } },
-                });
-              }}
-            ></ss-toggle>
-          </div>
+        <div class="filter-row">
+          <ss-button
+            @click=${(): void => {
+              this.filterPopupOpen = true;
+            }}
+          >${translate('configureFilter')}</ss-button>
         </div>
-        <div class="row">
-          <div class="field">
-            <label>${translate('timeFilter')}</label>
-            <ss-select
-              .options=${timeTypeOptions}
-              .selected=${timeType}
-              @select-changed=${(e: SelectChangedEvent<ListFilterTimeType>): void => {
-                let newTime: TimeContext;
-                if (e.detail.value === ListFilterTimeType.EXACT_DATE) {
-                  newTime = { type: ListFilterTimeType.EXACT_DATE, date: '' };
-                } else if (e.detail.value === ListFilterTimeType.RANGE) {
-                  newTime = { type: ListFilterTimeType.RANGE, start: '', end: '' };
-                } else {
-                  newTime = { type: ListFilterTimeType.ALL_TIME };
-                }
-                this.emit({ ...fr, context: { ...context, filter: { ...filter, time: newTime } } });
-              }}
-            ></ss-select>
-          </div>
-        </div>
-        ${timeType === ListFilterTimeType.EXACT_DATE
-          ? html`
-              <div class="row">
-                <div class="field">
-                  <label>${translate('date')}</label>
-                  <input
-                    type="date"
-                    .value=${(filter.time as { date: string }).date ?? ''}
-                    @change=${(e: Event): void => {
-                      const date = (e.target as HTMLInputElement).value;
-                      this.emit({
-                        ...fr,
-                        context: {
-                          ...context,
-                          filter: { ...filter, time: { type: ListFilterTimeType.EXACT_DATE, date } },
-                        },
-                      });
-                    }}
-                  />
-                </div>
-              </div>
-            `
-          : nothing}
-        ${timeType === ListFilterTimeType.RANGE
-          ? html`
-              <div class="row">
-                <div class="field">
-                  <label>${translate('startDate')}</label>
-                  <input
-                    type="date"
-                    .value=${(filter.time as { start: string; end: string }).start ?? ''}
-                    @change=${(e: Event): void => {
-                      const start = (e.target as HTMLInputElement).value;
-                      const current = filter.time as { start: string; end: string };
-                      this.emit({
-                        ...fr,
-                        context: {
-                          ...context,
-                          filter: {
-                            ...filter,
-                            time: { type: ListFilterTimeType.RANGE, start, end: current.end ?? '' },
-                          },
-                        },
-                      });
-                    }}
-                  />
-                </div>
-                <div class="field">
-                  <label>${translate('endDate')}</label>
-                  <input
-                    type="date"
-                    .value=${(filter.time as { start: string; end: string }).end ?? ''}
-                    @change=${(e: Event): void => {
-                      const end = (e.target as HTMLInputElement).value;
-                      const current = filter.time as { start: string; end: string };
-                      this.emit({
-                        ...fr,
-                        context: {
-                          ...context,
-                          filter: {
-                            ...filter,
-                            time: {
-                              type: ListFilterTimeType.RANGE,
-                              start: current.start ?? '',
-                              end,
-                            },
-                          },
-                        },
-                      });
-                    }}
-                  />
-                </div>
-              </div>
-            `
-          : nothing}
+        <pop-up
+          ?open=${this.filterPopupOpen}
+          closeButton
+          closeOnOutsideClick
+          closeOnEsc
+          @pop-up-closed=${(): void => {
+            this.filterPopupOpen = false;
+          }}
+        >
+          <list-filter
+            .externalFilter=${context.filter}
+            @list-filter-updated=${(e: ListFilterUpdatedEvent): void => {
+              this.handleFilterUpdated(e, context, fr);
+            }}
+          ></list-filter>
+        </pop-up>
       </div>
     `;
   }
@@ -337,7 +221,7 @@ export class FactRequestEditor extends MobxLitElement {
       </div>
 
       ${operation === FactOperation.ENTITY_COUNT || operation === FactOperation.UNIQUE_TAG_COUNT
-        ? this.renderFilterFields(
+        ? this.renderFilterButton(
             fr.context as EntityCountFactContext | UniqueTagCountFactContext,
             fr,
           )

--- a/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
+++ b/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
@@ -201,6 +201,7 @@ export class FactRequestEditor extends MobxLitElement {
             .options=${operationOptions}
             .selected=${operation}
             @select-changed=${(e: SelectChangedEvent<FactOperation>): void => {
+              this.filterPopupOpen = false;
               const op = e.detail.value;
               let newContext;
               if (op === FactOperation.MEDAL_COUNT) {

--- a/src/lib/data/localization/en.json
+++ b/src/lib/data/localization/en.json
@@ -371,6 +371,7 @@
   "alias": "Alias",
   "operation": "Operation",
   "filterSettings": "Filter Settings",
+  "configureFilter": "Configure Filter",
   "includeAll": "Include All",
   "includeUntagged": "Include Untagged",
   "timeFilter": "Time Filter",


### PR DESCRIPTION
Replaces the limited inline filter fields in `fact-request-editor` with a "Configure Filter" button that opens the full `list-filter` component in a pop-up. Also adds an `externalFilter` prop to `list-filter` so it can be seeded with an arbitrary filter rather than always reading from appState.

Closes #150

Generated with [Claude Code](https://claude.ai/code)