### PR TITLE
fix: propagate updatedAt after entity save so displayed timestamp refreshes

### DIFF
--- a/src/components/entity-form/entity-form.events.ts
+++ b/src/components/entity-form/entity-form.events.ts
@@ -7,6 +7,7 @@ export interface EntityItemUpdatedEventPayload {
   tags: string[];
   properties: EntityProperty[];
   published: boolean;
+  updatedAt: string;
 }
 
 export class EntityItemUpdatedEvent extends CustomEvent<EntityItemUpdatedEventPayload> {

--- a/src/components/entity-form/entity-form.ts
+++ b/src/components/entity-form/entity-form.ts
@@ -639,6 +639,7 @@ export class EntityForm extends ViewElement {
             tags: this.tags,
             properties: result.properties,
             published: payload.published,
+            updatedAt: result.updatedAt,
           }),
         );
 

--- a/src/components/entity-list/entity-list.ts
+++ b/src/components/entity-list/entity-list.ts
@@ -195,7 +195,7 @@ export class EntityList extends ViewElement {
   }
 
   private handleItemUpdated(e: EntityItemUpdatedEvent): void {
-    const { properties, tags, published } = e.detail;
+    const { properties, tags, published, updatedAt } = e.detail;
 
     const updatedList = this.state.listEntities.map(item =>
       item.id === e.detail.id
@@ -204,6 +204,7 @@ export class EntityList extends ViewElement {
             properties,
             tags,
             published,
+            updatedAt,
           }
         : item,
     );


### PR DESCRIPTION
After saving an entity, the EntityItemUpdatedEvent was missing the updatedAt field, so the list item retained the old timestamp. Now the event carries result.updatedAt from storage and the list handler applies it to the local entity state.

Fixes #159

Generated with [Claude Code](https://claude.ai/code)