### PR TITLE
feat: ability to hide parts of list-filter

### DIFF
--- a/src/components/entity-list-customizer/entity-list-customizer.ts
+++ b/src/components/entity-list-customizer/entity-list-customizer.ts
@@ -72,6 +72,7 @@ export class EntityListCustomizer extends MobxLitElement {
             ] || false}
           >
             <list-filter
+              all
               @list-filter-updated=${this.handleFilterUpdated}
             ></list-filter>
           </ss-collapsable>

--- a/src/components/entity-list-customizer/entity-list-customizer.ts
+++ b/src/components/entity-list-customizer/entity-list-customizer.ts
@@ -72,7 +72,7 @@ export class EntityListCustomizer extends MobxLitElement {
             ] || false}
           >
             <list-filter
-              all
+              showAll
               @list-filter-updated=${this.handleFilterUpdated}
             ></list-filter>
           </ss-collapsable>

--- a/src/components/list-config/list-config.ts
+++ b/src/components/list-config/list-config.ts
@@ -803,7 +803,7 @@ export class ListConfig extends MobxLitElement {
         >
           <div class="filter-body">
             <list-filter
-              all
+              showAll
               .listFilter=${this.state.listFilter}
               @list-filter-updated=${this.handleFilterUpdated}
             ></list-filter>

--- a/src/components/list-config/list-config.ts
+++ b/src/components/list-config/list-config.ts
@@ -803,6 +803,7 @@ export class ListConfig extends MobxLitElement {
         >
           <div class="filter-body">
             <list-filter
+              all
               .listFilter=${this.state.listFilter}
               @list-filter-updated=${this.handleFilterUpdated}
             ></list-filter>

--- a/src/components/list-filter/list-filter.models.ts
+++ b/src/components/list-filter/list-filter.models.ts
@@ -4,10 +4,26 @@ import { ListFilter as ListFilterSpec } from 'api-spec/models/List';
 
 export enum ListFilterProp {
   LIST_FILTER = 'listFilter',
+  ALL = 'all',
+  TYPES = 'types',
+  PROPERTIES = 'properties',
+  PUBLISHED = 'published',
+  SUGGESTED = 'suggested',
+  IDENTIFIED = 'identified',
+  TAGGING = 'tagging',
+  TIME = 'time',
 }
 
 export interface ListFilterProps extends PropTypes {
   [ListFilterProp.LIST_FILTER]: ListFilterSpec | undefined;
+  [ListFilterProp.ALL]: boolean;
+  [ListFilterProp.TYPES]: boolean;
+  [ListFilterProp.PROPERTIES]: boolean;
+  [ListFilterProp.PUBLISHED]: boolean;
+  [ListFilterProp.SUGGESTED]: boolean;
+  [ListFilterProp.IDENTIFIED]: boolean;
+  [ListFilterProp.TAGGING]: boolean;
+  [ListFilterProp.TIME]: boolean;
 }
 
 export const listFilterProps: PropConfigMap<ListFilterProps> = {
@@ -15,5 +31,45 @@ export const listFilterProps: PropConfigMap<ListFilterProps> = {
     default: undefined,
     control: { type: ControlType.HIDDEN },
     description: 'Filter value passed in from outside',
+  },
+  [ListFilterProp.ALL]: {
+    default: false,
+    control: { type: ControlType.BOOLEAN },
+    description: 'Show all filter sections',
+  },
+  [ListFilterProp.TYPES]: {
+    default: false,
+    control: { type: ControlType.BOOLEAN },
+    description: 'Show the types filter section',
+  },
+  [ListFilterProp.PROPERTIES]: {
+    default: false,
+    control: { type: ControlType.BOOLEAN },
+    description: 'Show the properties filter section',
+  },
+  [ListFilterProp.PUBLISHED]: {
+    default: false,
+    control: { type: ControlType.BOOLEAN },
+    description: 'Show the published filter section',
+  },
+  [ListFilterProp.SUGGESTED]: {
+    default: false,
+    control: { type: ControlType.BOOLEAN },
+    description: 'Show the suggested filter section',
+  },
+  [ListFilterProp.IDENTIFIED]: {
+    default: false,
+    control: { type: ControlType.BOOLEAN },
+    description: 'Show the identified filter section',
+  },
+  [ListFilterProp.TAGGING]: {
+    default: false,
+    control: { type: ControlType.BOOLEAN },
+    description: 'Show the tagging filter section',
+  },
+  [ListFilterProp.TIME]: {
+    default: false,
+    control: { type: ControlType.BOOLEAN },
+    description: 'Show the time filter section',
   },
 };

--- a/src/components/list-filter/list-filter.models.ts
+++ b/src/components/list-filter/list-filter.models.ts
@@ -4,26 +4,26 @@ import { ListFilter as ListFilterSpec } from 'api-spec/models/List';
 
 export enum ListFilterProp {
   LIST_FILTER = 'listFilter',
-  ALL = 'all',
-  TYPES = 'types',
-  PROPERTIES = 'properties',
-  PUBLISHED = 'published',
-  SUGGESTED = 'suggested',
-  IDENTIFIED = 'identified',
-  TAGGING = 'tagging',
-  TIME = 'time',
+  SHOW_ALL = 'showAll',
+  SHOW_TYPES = 'showTypes',
+  SHOW_PROPERTIES = 'showProperties',
+  SHOW_PUBLISHED = 'showPublished',
+  SHOW_SUGGESTED = 'showSuggested',
+  SHOW_IDENTIFIED = 'showIdentified',
+  SHOW_TAGGING = 'showTagging',
+  SHOW_TIME = 'showTime',
 }
 
 export interface ListFilterProps extends PropTypes {
   [ListFilterProp.LIST_FILTER]: ListFilterSpec | undefined;
-  [ListFilterProp.ALL]: boolean;
-  [ListFilterProp.TYPES]: boolean;
-  [ListFilterProp.PROPERTIES]: boolean;
-  [ListFilterProp.PUBLISHED]: boolean;
-  [ListFilterProp.SUGGESTED]: boolean;
-  [ListFilterProp.IDENTIFIED]: boolean;
-  [ListFilterProp.TAGGING]: boolean;
-  [ListFilterProp.TIME]: boolean;
+  [ListFilterProp.SHOW_ALL]: boolean;
+  [ListFilterProp.SHOW_TYPES]: boolean;
+  [ListFilterProp.SHOW_PROPERTIES]: boolean;
+  [ListFilterProp.SHOW_PUBLISHED]: boolean;
+  [ListFilterProp.SHOW_SUGGESTED]: boolean;
+  [ListFilterProp.SHOW_IDENTIFIED]: boolean;
+  [ListFilterProp.SHOW_TAGGING]: boolean;
+  [ListFilterProp.SHOW_TIME]: boolean;
 }
 
 export const listFilterProps: PropConfigMap<ListFilterProps> = {
@@ -32,42 +32,42 @@ export const listFilterProps: PropConfigMap<ListFilterProps> = {
     control: { type: ControlType.HIDDEN },
     description: 'Filter value passed in from outside',
   },
-  [ListFilterProp.ALL]: {
+  [ListFilterProp.SHOW_ALL]: {
     default: false,
     control: { type: ControlType.BOOLEAN },
     description: 'Show all filter sections',
   },
-  [ListFilterProp.TYPES]: {
+  [ListFilterProp.SHOW_TYPES]: {
     default: false,
     control: { type: ControlType.BOOLEAN },
     description: 'Show the types filter section',
   },
-  [ListFilterProp.PROPERTIES]: {
+  [ListFilterProp.SHOW_PROPERTIES]: {
     default: false,
     control: { type: ControlType.BOOLEAN },
     description: 'Show the properties filter section',
   },
-  [ListFilterProp.PUBLISHED]: {
+  [ListFilterProp.SHOW_PUBLISHED]: {
     default: false,
     control: { type: ControlType.BOOLEAN },
     description: 'Show the published filter section',
   },
-  [ListFilterProp.SUGGESTED]: {
+  [ListFilterProp.SHOW_SUGGESTED]: {
     default: false,
     control: { type: ControlType.BOOLEAN },
     description: 'Show the suggested filter section',
   },
-  [ListFilterProp.IDENTIFIED]: {
+  [ListFilterProp.SHOW_IDENTIFIED]: {
     default: false,
     control: { type: ControlType.BOOLEAN },
     description: 'Show the identified filter section',
   },
-  [ListFilterProp.TAGGING]: {
+  [ListFilterProp.SHOW_TAGGING]: {
     default: false,
     control: { type: ControlType.BOOLEAN },
     description: 'Show the tagging filter section',
   },
-  [ListFilterProp.TIME]: {
+  [ListFilterProp.SHOW_TIME]: {
     default: false,
     control: { type: ControlType.BOOLEAN },
     description: 'Show the time filter section',

--- a/src/components/list-filter/list-filter.ts
+++ b/src/components/list-filter/list-filter.ts
@@ -84,36 +84,36 @@ export class ListFilter extends MobxLitElement {
     listFilterProps[ListFilterProp.LIST_FILTER].default;
 
   @property({ type: Boolean })
-  [ListFilterProp.ALL]: ListFilterProps[ListFilterProp.ALL] =
-    listFilterProps[ListFilterProp.ALL].default;
+  [ListFilterProp.SHOW_ALL]: ListFilterProps[ListFilterProp.SHOW_ALL] =
+    listFilterProps[ListFilterProp.SHOW_ALL].default;
 
   @property({ type: Boolean })
-  [ListFilterProp.TYPES]: ListFilterProps[ListFilterProp.TYPES] =
-    listFilterProps[ListFilterProp.TYPES].default;
+  [ListFilterProp.SHOW_TYPES]: ListFilterProps[ListFilterProp.SHOW_TYPES] =
+    listFilterProps[ListFilterProp.SHOW_TYPES].default;
 
   @property({ type: Boolean })
-  [ListFilterProp.PROPERTIES]: ListFilterProps[ListFilterProp.PROPERTIES] =
-    listFilterProps[ListFilterProp.PROPERTIES].default;
+  [ListFilterProp.SHOW_PROPERTIES]: ListFilterProps[ListFilterProp.SHOW_PROPERTIES] =
+    listFilterProps[ListFilterProp.SHOW_PROPERTIES].default;
 
   @property({ type: Boolean })
-  [ListFilterProp.PUBLISHED]: ListFilterProps[ListFilterProp.PUBLISHED] =
-    listFilterProps[ListFilterProp.PUBLISHED].default;
+  [ListFilterProp.SHOW_PUBLISHED]: ListFilterProps[ListFilterProp.SHOW_PUBLISHED] =
+    listFilterProps[ListFilterProp.SHOW_PUBLISHED].default;
 
   @property({ type: Boolean })
-  [ListFilterProp.SUGGESTED]: ListFilterProps[ListFilterProp.SUGGESTED] =
-    listFilterProps[ListFilterProp.SUGGESTED].default;
+  [ListFilterProp.SHOW_SUGGESTED]: ListFilterProps[ListFilterProp.SHOW_SUGGESTED] =
+    listFilterProps[ListFilterProp.SHOW_SUGGESTED].default;
 
   @property({ type: Boolean })
-  [ListFilterProp.IDENTIFIED]: ListFilterProps[ListFilterProp.IDENTIFIED] =
-    listFilterProps[ListFilterProp.IDENTIFIED].default;
+  [ListFilterProp.SHOW_IDENTIFIED]: ListFilterProps[ListFilterProp.SHOW_IDENTIFIED] =
+    listFilterProps[ListFilterProp.SHOW_IDENTIFIED].default;
 
   @property({ type: Boolean })
-  [ListFilterProp.TAGGING]: ListFilterProps[ListFilterProp.TAGGING] =
-    listFilterProps[ListFilterProp.TAGGING].default;
+  [ListFilterProp.SHOW_TAGGING]: ListFilterProps[ListFilterProp.SHOW_TAGGING] =
+    listFilterProps[ListFilterProp.SHOW_TAGGING].default;
 
   @property({ type: Boolean })
-  [ListFilterProp.TIME]: ListFilterProps[ListFilterProp.TIME] =
-    listFilterProps[ListFilterProp.TIME].default;
+  [ListFilterProp.SHOW_TIME]: ListFilterProps[ListFilterProp.SHOW_TIME] =
+    listFilterProps[ListFilterProp.SHOW_TIME].default;
 
   @state() [ListFilterType.CONTAINS_ONE_OF]: string[] = [];
   @state() [ListFilterType.CONTAINS_ALL_OF]: string[] = [];
@@ -122,12 +122,12 @@ export class ListFilter extends MobxLitElement {
   @state() includeUntagged: boolean = false;
   @state() includeAll: boolean = true;
   @state() includeAllTagging: boolean = false;
-  @state() timeContext: TimeContext = { type: ListFilterTimeType.ALL_TIME };
+  @state() time: TimeContext = { type: ListFilterTimeType.ALL_TIME };
   @state() text: TextContext[] = [];
-  @state() filterProperties: FilterProperty[] = [];
-  @state() publishedFilter: boolean | null = null;
-  @state() suggestedFilter: boolean | null = null;
-  @state() identifiedFilter: boolean | null = null;
+  @state() properties: FilterProperty[] = [];
+  @state() published: boolean | null = null;
+  @state() suggested: boolean | null = null;
+  @state() identified: boolean | null = null;
 
   @state() savedFilters: SavedListFilter[] = [];
   @state() saveMode: boolean = false;
@@ -184,13 +184,11 @@ export class ListFilter extends MobxLitElement {
         containsOneOf: this.containsOneOf,
         containsAllOf: this.containsAllOf,
       },
-      time: this.timeContext,
-      properties: this.filterProperties,
-      ...(this.publishedFilter !== null && { published: this.publishedFilter }),
-      ...(this.suggestedFilter !== null && { suggested: this.suggestedFilter }),
-      ...(this.identifiedFilter !== null && {
-        identified: this.identifiedFilter,
-      }),
+      time: this.time,
+      properties: this.properties,
+      ...(this.published !== null && { published: this.published }),
+      ...(this.suggested !== null && { suggested: this.suggested }),
+      ...(this.identified !== null && { identified: this.identified }),
     };
   }
 
@@ -219,16 +217,16 @@ export class ListFilter extends MobxLitElement {
     this.includeAll = listFilter.includeAll ?? true;
     this.includeAllTagging = listFilter.includeAllTagging ?? true;
     if (listFilter.time) {
-      this.timeContext = listFilter.time;
+      this.time = listFilter.time;
     }
     if (listFilter.properties) {
-      this.filterProperties = listFilter.properties;
+      this.properties = listFilter.properties;
     }
-    this.publishedFilter =
+    this.published =
       listFilter.published !== undefined ? listFilter.published : null;
-    this.suggestedFilter =
+    this.suggested =
       listFilter.suggested !== undefined ? listFilter.suggested : null;
-    this.identifiedFilter =
+    this.identified =
       listFilter.identified !== undefined ? listFilter.identified : null;
   }
 
@@ -249,11 +247,11 @@ export class ListFilter extends MobxLitElement {
   }
 
   private handleTimeChanged(e: TimeFiltersUpdatedEvent): void {
-    this.timeContext = e.detail;
+    this.time = e.detail;
   }
 
   private handlePropertiesChanged(e: FilterPropertiesUpdatedEvent): void {
-    this.filterProperties = e.detail.filters;
+    this.properties = e.detail.filters;
   }
 
   private updateTags(type: ListFilterType, tags: string[]): void {
@@ -298,65 +296,67 @@ export class ListFilter extends MobxLitElement {
   private handlePublishedChanged(e: OptionSelectorChangedEvent): void {
     const { selected } = e.detail;
     if (selected.includes('true') && selected.includes('false')) {
-      this.publishedFilter = null;
+      this.published = null;
     } else if (selected.includes('true')) {
-      this.publishedFilter = true;
+      this.published = true;
     } else if (selected.includes('false')) {
-      this.publishedFilter = false;
+      this.published = false;
     } else {
-      this.publishedFilter = null;
+      this.published = null;
     }
   }
 
   private handleSuggestedChanged(e: OptionSelectorChangedEvent): void {
     const { selected } = e.detail;
     if (selected.includes('true') && selected.includes('false')) {
-      this.suggestedFilter = null;
+      this.suggested = null;
     } else if (selected.includes('true')) {
-      this.suggestedFilter = true;
+      this.suggested = true;
     } else if (selected.includes('false')) {
-      this.suggestedFilter = false;
+      this.suggested = false;
     } else {
-      this.suggestedFilter = null;
+      this.suggested = null;
     }
   }
 
   private handleIdentifiedChanged(e: OptionSelectorChangedEvent): void {
     const { selected } = e.detail;
     if (selected.includes('true') && selected.includes('false')) {
-      this.identifiedFilter = null;
+      this.identified = null;
     } else if (selected.includes('true')) {
-      this.identifiedFilter = true;
+      this.identified = true;
     } else if (selected.includes('false')) {
-      this.identifiedFilter = false;
+      this.identified = false;
     } else {
-      this.identifiedFilter = null;
+      this.identified = null;
     }
   }
 
   private publishedToSelected(): string[] {
-    if (this.publishedFilter === null) {
+    if (this.published === null) {
       return ['true', 'false'];
     }
-    return [String(this.publishedFilter)];
+    return [String(this.published)];
   }
 
   private suggestedToSelected(): string[] {
-    if (this.suggestedFilter === null) {
+    if (this.suggested === null) {
       return ['true', 'false'];
     }
-    return [String(this.suggestedFilter)];
+    return [String(this.suggested)];
   }
 
   private identifiedToSelected(): string[] {
-    if (this.identifiedFilter === null) {
+    if (this.identified === null) {
       return ['true', 'false'];
     }
-    return [String(this.identifiedFilter)];
+    return [String(this.identified)];
   }
 
   private isVisible(section: ListFilterProp): boolean {
-    return this[ListFilterProp.ALL] || (this[section as keyof this] as boolean);
+    return (
+      this[ListFilterProp.SHOW_ALL] || (this[section as keyof this] as boolean)
+    );
   }
 
   render(): TemplateResult {
@@ -374,7 +374,7 @@ export class ListFilter extends MobxLitElement {
         </div>
 
         <div class="filters">
-          ${this.isVisible(ListFilterProp.TYPES)
+          ${this.isVisible(ListFilterProp.SHOW_TYPES)
             ? html`
                 <fieldset>
                   <legend>${translate('includedTypes')}</legend>
@@ -392,18 +392,18 @@ export class ListFilter extends MobxLitElement {
                 </fieldset>
               `
             : nothing}
-          ${this.isVisible(ListFilterProp.PROPERTIES)
+          ${this.isVisible(ListFilterProp.SHOW_PROPERTIES)
             ? html`
                 <filter-properties
                   .includeTypes=${this.includeTypes}
-                  .filters=${this.filterProperties}
+                  .filters=${this.properties}
                   @filter-properties-updated=${(
                     e: FilterPropertiesUpdatedEvent,
                   ): void => this.handlePropertiesChanged(e)}
                 ></filter-properties>
               `
             : nothing}
-          ${this.isVisible(ListFilterProp.PUBLISHED)
+          ${this.isVisible(ListFilterProp.SHOW_PUBLISHED)
             ? html`
                 <fieldset>
                   <legend>${translate('published')}</legend>
@@ -422,7 +422,7 @@ export class ListFilter extends MobxLitElement {
                 </fieldset>
               `
             : nothing}
-          ${this.isVisible(ListFilterProp.SUGGESTED)
+          ${this.isVisible(ListFilterProp.SHOW_SUGGESTED)
             ? html`
                 <fieldset>
                   <legend>${translate('suggested')}</legend>
@@ -441,7 +441,7 @@ export class ListFilter extends MobxLitElement {
                 </fieldset>
               `
             : nothing}
-          ${this.isVisible(ListFilterProp.IDENTIFIED)
+          ${this.isVisible(ListFilterProp.SHOW_IDENTIFIED)
             ? html`
                 <fieldset>
                   <legend>${translate('identified')}</legend>
@@ -460,7 +460,7 @@ export class ListFilter extends MobxLitElement {
                 </fieldset>
               `
             : nothing}
-          ${this.isVisible(ListFilterProp.TAGGING)
+          ${this.isVisible(ListFilterProp.SHOW_TAGGING)
             ? html`
                 <fieldset class=${classMap(this.taggingClasses)}>
                   <legend>${translate('tagging')}</legend>
@@ -530,18 +530,18 @@ export class ListFilter extends MobxLitElement {
                 </fieldset>
               `
             : nothing}
-          ${this.isVisible(ListFilterProp.TIME)
+          ${this.isVisible(ListFilterProp.SHOW_TIME)
             ? html`
                 <time-filters
-                  type=${this.timeContext.type}
-                  date=${this.timeContext.type === ListFilterTimeType.EXACT_DATE
-                    ? this.timeContext.date
+                  type=${this.time.type}
+                  date=${this.time.type === ListFilterTimeType.EXACT_DATE
+                    ? this.time.date
                     : ''}
-                  start=${this.timeContext.type === ListFilterTimeType.RANGE
-                    ? this.timeContext.start
+                  start=${this.time.type === ListFilterTimeType.RANGE
+                    ? this.time.start
                     : ''}
-                  end=${this.timeContext.type === ListFilterTimeType.RANGE
-                    ? this.timeContext.end
+                  end=${this.time.type === ListFilterTimeType.RANGE
+                    ? this.time.end
                     : ''}
                   @time-filters-updated=${(e: TimeFiltersUpdatedEvent): void =>
                     this.handleTimeChanged(e)}

--- a/src/components/list-filter/list-filter.ts
+++ b/src/components/list-filter/list-filter.ts
@@ -1,4 +1,4 @@
-import { html, css, PropertyValues, TemplateResult } from 'lit';
+import { html, css, nothing, PropertyValues, TemplateResult } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -83,6 +83,38 @@ export class ListFilter extends MobxLitElement {
   [ListFilterProp.LIST_FILTER]: ListFilterProps[ListFilterProp.LIST_FILTER] =
     listFilterProps[ListFilterProp.LIST_FILTER].default;
 
+  @property({ type: Boolean })
+  [ListFilterProp.ALL]: ListFilterProps[ListFilterProp.ALL] =
+    listFilterProps[ListFilterProp.ALL].default;
+
+  @property({ type: Boolean })
+  [ListFilterProp.TYPES]: ListFilterProps[ListFilterProp.TYPES] =
+    listFilterProps[ListFilterProp.TYPES].default;
+
+  @property({ type: Boolean })
+  [ListFilterProp.PROPERTIES]: ListFilterProps[ListFilterProp.PROPERTIES] =
+    listFilterProps[ListFilterProp.PROPERTIES].default;
+
+  @property({ type: Boolean })
+  [ListFilterProp.PUBLISHED]: ListFilterProps[ListFilterProp.PUBLISHED] =
+    listFilterProps[ListFilterProp.PUBLISHED].default;
+
+  @property({ type: Boolean })
+  [ListFilterProp.SUGGESTED]: ListFilterProps[ListFilterProp.SUGGESTED] =
+    listFilterProps[ListFilterProp.SUGGESTED].default;
+
+  @property({ type: Boolean })
+  [ListFilterProp.IDENTIFIED]: ListFilterProps[ListFilterProp.IDENTIFIED] =
+    listFilterProps[ListFilterProp.IDENTIFIED].default;
+
+  @property({ type: Boolean })
+  [ListFilterProp.TAGGING]: ListFilterProps[ListFilterProp.TAGGING] =
+    listFilterProps[ListFilterProp.TAGGING].default;
+
+  @property({ type: Boolean })
+  [ListFilterProp.TIME]: ListFilterProps[ListFilterProp.TIME] =
+    listFilterProps[ListFilterProp.TIME].default;
+
   @state() [ListFilterType.CONTAINS_ONE_OF]: string[] = [];
   @state() [ListFilterType.CONTAINS_ALL_OF]: string[] = [];
   @state() userIds: string[] = [];
@@ -90,12 +122,12 @@ export class ListFilter extends MobxLitElement {
   @state() includeUntagged: boolean = false;
   @state() includeAll: boolean = true;
   @state() includeAllTagging: boolean = false;
-  @state() time: TimeContext = { type: ListFilterTimeType.ALL_TIME };
+  @state() timeContext: TimeContext = { type: ListFilterTimeType.ALL_TIME };
   @state() text: TextContext[] = [];
-  @state() properties: FilterProperty[] = [];
-  @state() published: boolean | null = null;
-  @state() suggested: boolean | null = null;
-  @state() identified: boolean | null = null;
+  @state() filterProperties: FilterProperty[] = [];
+  @state() publishedFilter: boolean | null = null;
+  @state() suggestedFilter: boolean | null = null;
+  @state() identifiedFilter: boolean | null = null;
 
   @state() savedFilters: SavedListFilter[] = [];
   @state() saveMode: boolean = false;
@@ -152,11 +184,13 @@ export class ListFilter extends MobxLitElement {
         containsOneOf: this.containsOneOf,
         containsAllOf: this.containsAllOf,
       },
-      time: this.time,
-      properties: this.properties,
-      ...(this.published !== null && { published: this.published }),
-      ...(this.suggested !== null && { suggested: this.suggested }),
-      ...(this.identified !== null && { identified: this.identified }),
+      time: this.timeContext,
+      properties: this.filterProperties,
+      ...(this.publishedFilter !== null && { published: this.publishedFilter }),
+      ...(this.suggestedFilter !== null && { suggested: this.suggestedFilter }),
+      ...(this.identifiedFilter !== null && {
+        identified: this.identifiedFilter,
+      }),
     };
   }
 
@@ -185,16 +219,16 @@ export class ListFilter extends MobxLitElement {
     this.includeAll = listFilter.includeAll ?? true;
     this.includeAllTagging = listFilter.includeAllTagging ?? true;
     if (listFilter.time) {
-      this.time = listFilter.time;
+      this.timeContext = listFilter.time;
     }
     if (listFilter.properties) {
-      this.properties = listFilter.properties;
+      this.filterProperties = listFilter.properties;
     }
-    this.published =
+    this.publishedFilter =
       listFilter.published !== undefined ? listFilter.published : null;
-    this.suggested =
+    this.suggestedFilter =
       listFilter.suggested !== undefined ? listFilter.suggested : null;
-    this.identified =
+    this.identifiedFilter =
       listFilter.identified !== undefined ? listFilter.identified : null;
   }
 
@@ -215,11 +249,11 @@ export class ListFilter extends MobxLitElement {
   }
 
   private handleTimeChanged(e: TimeFiltersUpdatedEvent): void {
-    this.time = e.detail;
+    this.timeContext = e.detail;
   }
 
   private handlePropertiesChanged(e: FilterPropertiesUpdatedEvent): void {
-    this.properties = e.detail.filters;
+    this.filterProperties = e.detail.filters;
   }
 
   private updateTags(type: ListFilterType, tags: string[]): void {
@@ -264,61 +298,65 @@ export class ListFilter extends MobxLitElement {
   private handlePublishedChanged(e: OptionSelectorChangedEvent): void {
     const { selected } = e.detail;
     if (selected.includes('true') && selected.includes('false')) {
-      this.published = null;
+      this.publishedFilter = null;
     } else if (selected.includes('true')) {
-      this.published = true;
+      this.publishedFilter = true;
     } else if (selected.includes('false')) {
-      this.published = false;
+      this.publishedFilter = false;
     } else {
-      this.published = null;
+      this.publishedFilter = null;
     }
   }
 
   private handleSuggestedChanged(e: OptionSelectorChangedEvent): void {
     const { selected } = e.detail;
     if (selected.includes('true') && selected.includes('false')) {
-      this.suggested = null;
+      this.suggestedFilter = null;
     } else if (selected.includes('true')) {
-      this.suggested = true;
+      this.suggestedFilter = true;
     } else if (selected.includes('false')) {
-      this.suggested = false;
+      this.suggestedFilter = false;
     } else {
-      this.suggested = null;
+      this.suggestedFilter = null;
     }
   }
 
   private handleIdentifiedChanged(e: OptionSelectorChangedEvent): void {
     const { selected } = e.detail;
     if (selected.includes('true') && selected.includes('false')) {
-      this.identified = null;
+      this.identifiedFilter = null;
     } else if (selected.includes('true')) {
-      this.identified = true;
+      this.identifiedFilter = true;
     } else if (selected.includes('false')) {
-      this.identified = false;
+      this.identifiedFilter = false;
     } else {
-      this.identified = null;
+      this.identifiedFilter = null;
     }
   }
 
   private publishedToSelected(): string[] {
-    if (this.published === null) {
+    if (this.publishedFilter === null) {
       return ['true', 'false'];
     }
-    return [String(this.published)];
+    return [String(this.publishedFilter)];
   }
 
   private suggestedToSelected(): string[] {
-    if (this.suggested === null) {
+    if (this.suggestedFilter === null) {
       return ['true', 'false'];
     }
-    return [String(this.suggested)];
+    return [String(this.suggestedFilter)];
   }
 
   private identifiedToSelected(): string[] {
-    if (this.identified === null) {
+    if (this.identifiedFilter === null) {
       return ['true', 'false'];
     }
-    return [String(this.identified)];
+    return [String(this.identifiedFilter)];
+  }
+
+  private isVisible(section: ListFilterProp): boolean {
+    return this[ListFilterProp.ALL] || (this[section as keyof this] as boolean);
   }
 
   render(): TemplateResult {
@@ -336,158 +374,180 @@ export class ListFilter extends MobxLitElement {
         </div>
 
         <div class="filters">
-          <fieldset>
-            <legend>${translate('includedTypes')}</legend>
-            <div class="types">
-              <ss-select
-                multiple
-                @select-changed=${this.handleTypesChanged}
-                .selected=${this.includeTypes.map(String)}
-                .options=${this.state.entityConfigs.map(config => ({
-                  label: config.name,
-                  value: config.id,
-                }))}
-              ></ss-select>
-            </div>
-          </fieldset>
+          ${this.isVisible(ListFilterProp.TYPES)
+            ? html`
+                <fieldset>
+                  <legend>${translate('includedTypes')}</legend>
+                  <div class="types">
+                    <ss-select
+                      multiple
+                      @select-changed=${this.handleTypesChanged}
+                      .selected=${this.includeTypes.map(String)}
+                      .options=${this.state.entityConfigs.map(config => ({
+                        label: config.name,
+                        value: config.id,
+                      }))}
+                    ></ss-select>
+                  </div>
+                </fieldset>
+              `
+            : nothing}
+          ${this.isVisible(ListFilterProp.PROPERTIES)
+            ? html`
+                <filter-properties
+                  .includeTypes=${this.includeTypes}
+                  .filters=${this.filterProperties}
+                  @filter-properties-updated=${(
+                    e: FilterPropertiesUpdatedEvent,
+                  ): void => this.handlePropertiesChanged(e)}
+                ></filter-properties>
+              `
+            : nothing}
+          ${this.isVisible(ListFilterProp.PUBLISHED)
+            ? html`
+                <fieldset>
+                  <legend>${translate('published')}</legend>
+                  <option-selector
+                    multiple
+                    required
+                    .options=${[
+                      { name: translate('published'), value: 'true' },
+                      { name: translate('unpublished'), value: 'false' },
+                    ]}
+                    .selected=${this.publishedToSelected()}
+                    @option-selector-changed=${(
+                      e: OptionSelectorChangedEvent,
+                    ): void => this.handlePublishedChanged(e)}
+                  ></option-selector>
+                </fieldset>
+              `
+            : nothing}
+          ${this.isVisible(ListFilterProp.SUGGESTED)
+            ? html`
+                <fieldset>
+                  <legend>${translate('suggested')}</legend>
+                  <option-selector
+                    multiple
+                    required
+                    .options=${[
+                      { name: translate('suggested'), value: 'true' },
+                      { name: translate('nonSuggested'), value: 'false' },
+                    ]}
+                    .selected=${this.suggestedToSelected()}
+                    @option-selector-changed=${(
+                      e: OptionSelectorChangedEvent,
+                    ): void => this.handleSuggestedChanged(e)}
+                  ></option-selector>
+                </fieldset>
+              `
+            : nothing}
+          ${this.isVisible(ListFilterProp.IDENTIFIED)
+            ? html`
+                <fieldset>
+                  <legend>${translate('identified')}</legend>
+                  <option-selector
+                    multiple
+                    required
+                    .options=${[
+                      { name: translate('identified'), value: 'true' },
+                      { name: translate('nonIdentified'), value: 'false' },
+                    ]}
+                    .selected=${this.identifiedToSelected()}
+                    @option-selector-changed=${(
+                      e: OptionSelectorChangedEvent,
+                    ): void => this.handleIdentifiedChanged(e)}
+                  ></option-selector>
+                </fieldset>
+              `
+            : nothing}
+          ${this.isVisible(ListFilterProp.TAGGING)
+            ? html`
+                <fieldset class=${classMap(this.taggingClasses)}>
+                  <legend>${translate('tagging')}</legend>
 
-          <filter-properties
-            .includeTypes=${this.includeTypes}
-            .filters=${this.properties}
-            @filter-properties-updated=${(
-              e: FilterPropertiesUpdatedEvent,
-            ): void => this.handlePropertiesChanged(e)}
-          ></filter-properties>
+                  <div class="all">
+                    <input
+                      id="include-all-tagging"
+                      type="checkbox"
+                      ?checked=${this.includeAllTagging}
+                      @change=${this.handleIncludeAllTaggingChanged}
+                    />
 
-          <fieldset>
-            <legend>${translate('published')}</legend>
-            <option-selector
-              multiple
-              required
-              .options=${[
-                { name: translate('published'), value: 'true' },
-                { name: translate('unpublished'), value: 'false' },
-              ]}
-              .selected=${this.publishedToSelected()}
-              @option-selector-changed=${(
-                e: OptionSelectorChangedEvent,
-              ): void => this.handlePublishedChanged(e)}
-            ></option-selector>
-          </fieldset>
-
-          <fieldset>
-            <legend>${translate('suggested')}</legend>
-            <option-selector
-              multiple
-              required
-              .options=${[
-                { name: translate('suggested'), value: 'true' },
-                { name: translate('nonSuggested'), value: 'false' },
-              ]}
-              .selected=${this.suggestedToSelected()}
-              @option-selector-changed=${(
-                e: OptionSelectorChangedEvent,
-              ): void => this.handleSuggestedChanged(e)}
-            ></option-selector>
-          </fieldset>
-
-          <fieldset>
-            <legend>${translate('identified')}</legend>
-            <option-selector
-              multiple
-              required
-              .options=${[
-                { name: translate('identified'), value: 'true' },
-                { name: translate('nonIdentified'), value: 'false' },
-              ]}
-              .selected=${this.identifiedToSelected()}
-              @option-selector-changed=${(
-                e: OptionSelectorChangedEvent,
-              ): void => this.handleIdentifiedChanged(e)}
-            ></option-selector>
-          </fieldset>
-
-          <fieldset class=${classMap(this.taggingClasses)}>
-            <legend>${translate('tagging')}</legend>
-
-            <div class="all">
-              <input
-                id="include-all-tagging"
-                type="checkbox"
-                ?checked=${this.includeAllTagging}
-                @change=${this.handleIncludeAllTaggingChanged}
-              />
-
-              <label for="include-all-tagging"
-                >${translate('includeAll')}</label
-              >
-            </div>
-
-            <div class="tag-rules">
-              ${repeat(
-                Object.values(ListFilterType),
-                type => type,
-                type => html`
-                  <fieldset>
-                    <legend>${translate(`filterType.${type}`)}</legend>
-
-                    <tag-manager
-                      ?enableSuggestions=${this.tagSuggestionsEnabled}
-                      @tags-updated=${(e: TagsUpdatedEvent): void => {
-                        this.updateTags(type, e.detail.tags);
-                      }}
-                      @tag-suggestions-requested=${this
-                        .handleTagSuggestionsRequested}
+                    <label for="include-all-tagging"
+                      >${translate('includeAll')}</label
                     >
-                      <div slot="tags">
-                        ${repeat(
-                          this[type],
-                          tag => tag,
-                          tag => html`<data-item>${tag}</data-item>`,
-                        )}
-                      </div>
+                  </div>
 
-                      <div slot="suggestions">
-                        ${repeat(
-                          this.tagSuggestions,
-                          suggestion => suggestion,
-                          suggestion =>
-                            html`<data-item>${suggestion}</data-item>`,
-                        )}
-                      </div>
-                    </tag-manager>
-                  </fieldset>
-                `,
-              )}
-              <div>
-                <input
-                  id="include-untagged"
-                  type="checkbox"
-                  ?checked=${this.includeUntagged}
-                  @change=${this.handleIncludeUntaggedChanged}
-                />
+                  <div class="tag-rules">
+                    ${repeat(
+                      Object.values(ListFilterType),
+                      type => type,
+                      type => html`
+                        <fieldset>
+                          <legend>${translate(`filterType.${type}`)}</legend>
 
-                <label for="include-untagged"
-                  >${translate('includeItemsWithoutTags')}</label
-                >
-              </div>
-            </div>
-          </fieldset>
+                          <tag-manager
+                            ?enableSuggestions=${this.tagSuggestionsEnabled}
+                            @tags-updated=${(e: TagsUpdatedEvent): void => {
+                              this.updateTags(type, e.detail.tags);
+                            }}
+                            @tag-suggestions-requested=${this
+                              .handleTagSuggestionsRequested}
+                          >
+                            <div slot="tags">
+                              ${repeat(
+                                this[type],
+                                tag => tag,
+                                tag => html`<data-item>${tag}</data-item>`,
+                              )}
+                            </div>
 
-          <time-filters
-            type=${this.time.type}
-            date=${this.time.type === ListFilterTimeType.EXACT_DATE
-              ? this.time.date
-              : ''}
-            start=${this.time.type === ListFilterTimeType.RANGE
-              ? this.time.start
-              : ''}
-            end=${this.time.type === ListFilterTimeType.RANGE
-              ? this.time.end
-              : ''}
-            @time-filters-updated=${(e: TimeFiltersUpdatedEvent): void =>
-              this.handleTimeChanged(e)}
-          ></time-filters>
+                            <div slot="suggestions">
+                              ${repeat(
+                                this.tagSuggestions,
+                                suggestion => suggestion,
+                                suggestion =>
+                                  html`<data-item>${suggestion}</data-item>`,
+                              )}
+                            </div>
+                          </tag-manager>
+                        </fieldset>
+                      `,
+                    )}
+                    <div>
+                      <input
+                        id="include-untagged"
+                        type="checkbox"
+                        ?checked=${this.includeUntagged}
+                        @change=${this.handleIncludeUntaggedChanged}
+                      />
+
+                      <label for="include-untagged"
+                        >${translate('includeItemsWithoutTags')}</label
+                      >
+                    </div>
+                  </div>
+                </fieldset>
+              `
+            : nothing}
+          ${this.isVisible(ListFilterProp.TIME)
+            ? html`
+                <time-filters
+                  type=${this.timeContext.type}
+                  date=${this.timeContext.type === ListFilterTimeType.EXACT_DATE
+                    ? this.timeContext.date
+                    : ''}
+                  start=${this.timeContext.type === ListFilterTimeType.RANGE
+                    ? this.timeContext.start
+                    : ''}
+                  end=${this.timeContext.type === ListFilterTimeType.RANGE
+                    ? this.timeContext.end
+                    : ''}
+                  @time-filters-updated=${(e: TimeFiltersUpdatedEvent): void =>
+                    this.handleTimeChanged(e)}
+                ></time-filters>
+              `
+            : nothing}
         </div>
 
         <ss-button

--- a/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
+++ b/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
@@ -142,7 +142,7 @@ export class FactRequestEditor extends MobxLitElement {
           }}
         >
           <list-filter
-            all
+            showAll
             .listFilter=${context.filter}
             @list-filter-updated=${(e: ListFilterUpdatedEvent): void => {
               this.handleFilterUpdated(e, context, fr);

--- a/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
+++ b/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
@@ -142,6 +142,7 @@ export class FactRequestEditor extends MobxLitElement {
           }}
         >
           <list-filter
+            all
             .listFilter=${context.filter}
             @list-filter-updated=${(e: ListFilterUpdatedEvent): void => {
               this.handleFilterUpdated(e, context, fr);


### PR DESCRIPTION
Add boolean visibility properties to list-filter component for each UI section (`types`, `properties`, `published`, `suggested`, `identified`, `tagging`, `time`) plus an `all` shorthand that enables all sections. All existing usages updated to include `all`.

Closes #163

Generated with [Claude Code](https://claude.ai/code)