### PR TITLE
fix: add touch-action manipulation to buttons in calculated-property-config-form

### DIFF
--- a/src/components/calculated-property-config-form/calculated-property-config-form.ts
+++ b/src/components/calculated-property-config-form/calculated-property-config-form.ts
@@ -94,6 +94,7 @@ export class CalculatedPropertyConfigForm extends LitElement {
 
     .buttons {
       padding: 0.5rem 0;
+      touch-action: manipulation;
 
       ss-button {
         display: block;


### PR DESCRIPTION
Fixes #162

The save button in the calculated property config form could not be tapped on mobile. The form is taller than regular property config forms (it has ~9 fields including formula preview, two operand pickers, and operation selector), so mobile users always need to scroll before reaching the save button.

The `sortable-item` component sets `draggable="true"` on its container div. On iOS/Android, after scrolling inside a draggable element, mobile browsers can interpret the next touch as a potential drag gesture instead of a tap, preventing the click event from firing.

Adding `touch-action: manipulation` to the `.buttons` container tells the browser to treat touches there as taps, bypassing drag gesture detection.

Generated with [Claude Code](https://claude.ai/code)