### PR TITLE
filter list-configs by active workspace in carousel

### DIFF
--- a/src/components/app-container/app-container.ts
+++ b/src/components/app-container/app-container.ts
@@ -186,6 +186,16 @@ export class AppContainer extends MobxLitElement {
   private handleWorkspaceChanged = (e: WorkspaceChangedEvent): void => {
     this.state.setActiveWorkspaceId(e.detail.workspaceId);
     this.state.setWorkspaceSelectorVisible(false);
+
+    const filtered = this.state.filteredListConfigs;
+    const currentInWorkspace = filtered.some(
+      c => c.id === this.state.listConfigId,
+    );
+    if (!currentInWorkspace) {
+      const newId = filtered.length ? filtered[0].id : '';
+      this.state.setListConfigId(newId);
+      storage.saveActiveListConfigId(newId);
+    }
   };
 
   private handleNetworkApiRequestFailed = (e: Event): void => {

--- a/src/components/list-config/list-config.ts
+++ b/src/components/list-config/list-config.ts
@@ -405,7 +405,7 @@ export class ListConfig extends MobxLitElement {
   }
 
   async setup(): Promise<void> {
-    const listConfigs = this.state.listConfigs;
+    const listConfigs = this.state.filteredListConfigs;
     if (this.state.hasFetchedListConfigs && !listConfigs.length) {
       await this.addConfig();
     }
@@ -515,7 +515,7 @@ export class ListConfig extends MobxLitElement {
       return;
     }
 
-    const config = this.state.listConfigs.find(
+    const config = this.state.filteredListConfigs.find(
       c => c.id === this.state.listConfigId,
     );
     if (!config) {
@@ -526,7 +526,7 @@ export class ListConfig extends MobxLitElement {
     this.id = config.id;
     this.name = config.name;
     this.navigationIndex =
-      this.state.listConfigs.findIndex(c => c.id === this.id) +
+      this.state.filteredListConfigs.findIndex(c => c.id === this.id) +
       (this[ListConfigProp.VIEW_ONLY] ? 0 : 1);
   }
 
@@ -549,7 +549,7 @@ export class ListConfig extends MobxLitElement {
         return;
       }
       const newListConfigId =
-        this.state.listConfigs[e.detail.slideIndex - 1]?.id;
+        this.state.filteredListConfigs[e.detail.slideIndex - 1]?.id;
       if (!newListConfigId || newListConfigId === this.state.listConfigId) {
         return;
       }
@@ -560,7 +560,7 @@ export class ListConfig extends MobxLitElement {
       return;
     }
 
-    const newListConfigId = this.state.listConfigs[e.detail.slideIndex]?.id;
+    const newListConfigId = this.state.filteredListConfigs[e.detail.slideIndex]?.id;
     if (!newListConfigId || newListConfigId === this.state.listConfigId) {
       return;
     }
@@ -664,7 +664,7 @@ export class ListConfig extends MobxLitElement {
                     </div>`
                   : nothing}
                 ${repeat(
-                  this.state.listConfigs,
+                  this.state.filteredListConfigs,
                   config => config.id,
                   config =>
                     html`<div class="config-slide">

--- a/src/state.ts
+++ b/src/state.ts
@@ -229,6 +229,21 @@ export class AppState {
     );
   }
 
+  get filteredListConfigs(): ListConfig[] {
+    if (!this.activeWorkspaceId || !this.workspaces.length) {
+      return this.listConfigs;
+    }
+    const activeWorkspace = this.workspaces.find(
+      w => w.id === this.activeWorkspaceId,
+    );
+    if (!activeWorkspace) {
+      return this.listConfigs;
+    }
+    return this.listConfigs.filter(c =>
+      activeWorkspace.listConfigs.includes(c.id),
+    );
+  }
+
   @action
   public setActionSuggestions(suggestions: string[]): void {
     this.actionSuggestions = suggestions;


### PR DESCRIPTION
Add `filteredListConfigs` computed getter to AppState that returns only the list-configs belonging to the active workspace. Falls back to all list-configs when no active workspace is set or no workspaces exist.

Update list-config carousel and app-container workspace change handler to use the filtered list, and reset the active list-config when switching to a workspace that doesn't include the current one.

Closes #172

Generated with [Claude Code](https://claude.ai/code)