### PR TITLE
fix: auto-add new list-config to active workspace on creation

### DIFF
--- a/src/components/list-config/list-config.ts
+++ b/src/components/list-config/list-config.ts
@@ -535,6 +535,23 @@ export class ListConfig extends MobxLitElement {
     addToast(translate('configAdded'), NotificationType.SUCCESS);
     const listConfigs = await storage.getListConfigs();
     this.state.setListConfigs(listConfigs);
+
+    if (this.state.activeWorkspaceId) {
+      const activeWorkspace = this.state.workspaces.find(
+        w => w.id === this.state.activeWorkspaceId,
+      );
+      if (activeWorkspace && !activeWorkspace.listConfigs.includes(id)) {
+        const updatedWorkspace = {
+          ...activeWorkspace,
+          listConfigs: [...activeWorkspace.listConfigs, id],
+        };
+        const result = await storage.saveWorkspace(updatedWorkspace);
+        if (result.isOk) {
+          this.state.upsertWorkspace(result.value);
+        }
+      }
+    }
+
     this.setListConfigId(id);
     this.sync();
   }


### PR DESCRIPTION
When adding a new list-config while a workspace is active, the config was not added to the workspace's listConfigs array, making it immediately inaccessible due to workspace filtering. Now saveWorkspace is called after creation to include the new config in the active workspace.

Fixes #175

Generated with [Claude Code](https://claude.ai/code)