### PR TITLE
fix: skip optionsOnly validation on blur when value is empty

### DIFF
--- a/src/components/entity-form/short-text-field/short-text-field.ts
+++ b/src/components/entity-form/short-text-field/short-text-field.ts
@@ -174,6 +174,7 @@ export class ShortTextField extends MobxLitElement {
   handleInputBlurred(_: InputChangedEvent): void {
     if (
       this.propertyConfig.optionsOnly &&
+      this._value.length > 0 &&
       !this.propertyConfig.options.includes(this._value)
     ) {
       addToast(


### PR DESCRIPTION
Fixes #177

When a form resets, the field's value is wiped to empty string. The blur event fires during teardown of the old property instances, and the optionsOnly check was incorrectly showing an error for the empty string case.

Added a `this._value.length > 0` guard so validation only runs when the user has actually entered something.

Generated with [Claude Code](https://claude.ai/code)