### PR TITLE
Filter entity config types to active workspace

### DIFF
--- a/src/components/entity-form/entity-form.ts
+++ b/src/components/entity-form/entity-form.ts
@@ -286,7 +286,7 @@ export class EntityForm extends ViewElement {
 
   @state()
   get availableEntityConfigs(): EntityConfig[] {
-    return this.state.entityConfigs.filter(
+    return this.state.workspaceEntityConfigs.filter(
       config =>
         (this.state.listFilter.includeTypes?.length ?? 0) === 0 ||
         this.state.listFilter.includeTypes?.includes(config.id),

--- a/src/components/list-filter/list-filter.ts
+++ b/src/components/list-filter/list-filter.ts
@@ -383,7 +383,7 @@ export class ListFilter extends MobxLitElement {
                       multiple
                       @select-changed=${this.handleTypesChanged}
                       .selected=${this.includeTypes.map(String)}
-                      .options=${this.state.entityConfigs.map(config => ({
+                      .options=${this.state.workspaceEntityConfigs.map(config => ({
                         label: config.name,
                         value: config.id,
                       }))}

--- a/src/state.ts
+++ b/src/state.ts
@@ -244,6 +244,26 @@ export class AppState {
     );
   }
 
+  get workspaceEntityConfigs(): EntityConfig[] {
+    if (!this.activeWorkspaceId || !this.workspaces.length) {
+      return this.entityConfigs;
+    }
+    const activeWorkspace = this.workspaces.find(
+      w => w.id === this.activeWorkspaceId,
+    );
+    if (!activeWorkspace || activeWorkspace.showEverything) {
+      return this.entityConfigs;
+    }
+    const typeIds = new Set<number>();
+    for (const listConfig of this.filteredListConfigs) {
+      if (!listConfig.filter.includeTypes?.length) {
+        return this.entityConfigs;
+      }
+      listConfig.filter.includeTypes.forEach(id => typeIds.add(id));
+    }
+    return this.entityConfigs.filter(config => typeIds.has(config.id));
+  }
+
   @action
   public setActionSuggestions(suggestions: string[]): void {
     this.actionSuggestions = suggestions;


### PR DESCRIPTION
Closes #181

Adds `workspaceEntityConfigs` getter to `AppState` that returns only entity configs referenced by the active workspace's list configs. Both `list-filter` and `entity-form` now use this filtered list instead of the full `entityConfigs` array.

**Behavior:**
- No active workspace → all entity config types shown
- Workspace has `showEverything` enabled → all entity config types shown
- Any workspace list config has no type restriction → all entity config types shown
- Otherwise → only entity config types referenced in the workspace's list configs

Generated with [Claude Code](https://claude.ai/code)