### PR TITLE
fix: show property filters in list-filter-preview

### DIFF
--- a/src/components/list-filter-preview/list-filter-preview.ts
+++ b/src/components/list-filter-preview/list-filter-preview.ts
@@ -96,6 +96,28 @@ export class ListFilterPreview extends MobxLitElement {
       }
     }
 
+    for (const propertyFilter of filter.properties ?? []) {
+      if (!propertyFilter.propertyId) {
+        continue;
+      }
+      const propertyConfig = this.state.propertyConfigs.find(
+        c => c.id === propertyFilter.propertyId,
+      );
+      if (!propertyConfig) {
+        continue;
+      }
+      const value = propertyFilter.value;
+      if (value === null || value === undefined || value === '') {
+        continue;
+      }
+      const operationLabel = translate(`textType.${propertyFilter.operation}`);
+      const displayValue =
+        typeof value === 'object'
+          ? translate('image')
+          : String(value);
+      parts.push(`${propertyConfig.name} ${operationLabel} ${displayValue}`);
+    }
+
     return parts;
   }
 


### PR DESCRIPTION
Fixes #185

The `list-filter-preview` component was not displaying property filters in its summary text. Added a loop over `filter.properties` in the `summaryParts` getter that looks up each property name from `state.propertyConfigs` and formats it as "{propertyName} {operation} {value}" (e.g. "Dosage Contains 50mg").

Generated with [Claude Code](https://claude.ai/code)