### PR TITLE
feat: add edit/update functionality for saved charts

### DIFF
--- a/src/components/chart-builder/chart-builder.events.ts
+++ b/src/components/chart-builder/chart-builder.events.ts
@@ -5,6 +5,7 @@ export const chartBuiltEventName = 'chart-built';
 export type ChartBuiltPayload = ChartResponse & {
   chartType: `${ChartConfigType}`;
   saved?: boolean;
+  updated?: boolean;
 };
 
 export class ChartBuiltEvent extends CustomEvent<ChartBuiltPayload> {

--- a/src/components/chart-builder/chart-builder.ts
+++ b/src/components/chart-builder/chart-builder.ts
@@ -1,11 +1,13 @@
-import { html, css, nothing, TemplateResult } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { html, css, nothing, PropertyValues, TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
 import {
+  Chart,
   ChartConfig,
   ChartConfigType,
+  ChartConfigV2,
   ChartRequest,
   ChartVersion,
   DataWindow,
@@ -32,6 +34,8 @@ import '@/components/data-point-builder/data-point-builder';
 
 @customElement('chart-builder')
 export class ChartBuilder extends MobxLitElement {
+  @property({ type: Object, attribute: false }) chart?: Chart;
+
   @state() private chartType: ChartConfigType = ChartConfigType.LINE;
   @state() private dataWindowType: DataWindowType = DataWindowType.LAST_30_DAYS;
   @state() private rollingDataWindow = false;
@@ -46,6 +50,32 @@ export class ChartBuilder extends MobxLitElement {
   @state() private isLoading = false;
   @state() private errorMessage = '';
   @state() private chartName = '';
+
+  updated(changedProperties: PropertyValues): void {
+    if (changedProperties.has('chart') && this.chart) {
+      this.initFromChart(this.chart);
+    }
+  }
+
+  private initFromChart(chart: Chart): void {
+    this.chartName = chart.name;
+    const config = chart.config;
+    if (config.version === ChartVersion.V2) {
+      this.chartType = (config as ChartConfigV2).type as ChartConfigType;
+    }
+    this.segmentationType = config.segmentation.type;
+    this.segmentationUnit = config.segmentation.unit;
+    this.dataPoints = structuredClone(config.dataPoints) as FactContext[];
+    if (config.dataWindow.type === DataWindowType.CUSTOM) {
+      this.dataWindowType = DataWindowType.CUSTOM;
+      this.rollingDataWindow = false;
+      this.customStart = new Date(config.dataWindow.start).toISOString().slice(0, 16);
+      this.customEnd = new Date(config.dataWindow.end).toISOString().slice(0, 16);
+    } else {
+      this.dataWindowType = config.dataWindow.type;
+      this.rollingDataWindow = true;
+    }
+  }
 
   static styles = css`
     .chart-builder {
@@ -240,19 +270,33 @@ export class ChartBuilder extends MobxLitElement {
       ...(save ? { save: true, name: this.chartName } : {}),
     };
 
-    const result = await storage.createChart?.(request);
+    let result;
+    if (save && this.chart) {
+      result = await storage.updateChart?.(this.chart.id, request);
+    } else {
+      result = await storage.createChart?.(request);
+    }
 
     this.isLoading = false;
 
     if (!result || !result.isOk) {
-      this.errorMessage = save
-        ? translate('failedToSaveChart')
-        : translate('failedToGenerateChart');
+      if (save && this.chart) {
+        this.errorMessage = translate('failedToUpdateChart');
+      } else if (save) {
+        this.errorMessage = translate('failedToSaveChart');
+      } else {
+        this.errorMessage = translate('failedToGenerateChart');
+      }
       return;
     }
 
     this.dispatchEvent(
-      new ChartBuiltEvent({ ...result.value, chartType: this.chartType, saved: save }),
+      new ChartBuiltEvent({
+        ...result.value,
+        chartType: this.chartType,
+        saved: save,
+        updated: save && !!this.chart,
+      }),
     );
   }
 
@@ -417,7 +461,13 @@ export class ChartBuilder extends MobxLitElement {
             ?disabled=${this.isLoading}
             @click=${(): Promise<void> => this.handleGenerateChart(true)}
           >
-            ${this.isLoading ? translate('saving') : translate('saveChart')}
+            ${this.isLoading
+              ? this.chart
+                ? translate('updating')
+                : translate('saving')
+              : this.chart
+                ? translate('updateChart')
+                : translate('saveChart')}
           </button>
           ${this.errorMessage
             ? html`<div class="error">${this.errorMessage}</div>`

--- a/src/components/chart-list/chart-list.ts
+++ b/src/components/chart-list/chart-list.ts
@@ -18,11 +18,13 @@ import { convertResponseToChartData } from '@/lib/ChartUtil';
 import { NotificationType } from '@ss/ui/components/notification-provider.models';
 import { CollapsableToggledEvent } from '@ss/ui/components/ss-collapsable.events';
 import { ConfirmationAcceptedEvent } from '@ss/ui/components/confirmation-modal.events';
+import { ChartBuiltEvent } from '@/components/chart-builder/chart-builder.events';
 
 import '@ss/ui/components/ss-collapsable';
 import '@ss/ui/components/ss-button';
 import '@ss/ui/components/confirmation-modal';
 import '@/components/chart-js/chart-js';
+import '@/components/chart-builder/chart-builder';
 
 @customElement('chart-list')
 export class ChartList extends MobxLitElement {
@@ -31,6 +33,7 @@ export class ChartList extends MobxLitElement {
   @state() private savedCharts: Chart[] = [];
   @state() private savedChartDataMap: Map<number, ChartData> = new Map();
   @state() private confirmDeleteChartId: number | null = null;
+  @state() private editingChartId: number | null = null;
 
   static styles = css`
     .saved-charts {
@@ -49,6 +52,8 @@ export class ChartList extends MobxLitElement {
     }
 
     .chart-actions {
+      display: flex;
+      gap: 0.5rem;
       padding: 0.75rem 0;
     }
 
@@ -112,8 +117,68 @@ export class ChartList extends MobxLitElement {
     addToast(translate('chartDeleted'), NotificationType.SUCCESS);
   }
 
+  private handleEditChart(id: number): void {
+    this.editingChartId = id;
+  }
+
+  private handleCancelEdit(): void {
+    this.editingChartId = null;
+  }
+
+  private async handleChartBuilt(e: ChartBuiltEvent): Promise<void> {
+    e.stopPropagation();
+    if (e.detail.updated) {
+      addToast(translate('chartUpdated'), NotificationType.SUCCESS);
+      this.editingChartId = null;
+      await this.loadCharts();
+    }
+  }
+
   private isPanelOpen(id: number): boolean {
     return this.appState.collapsablePanelState[`savedChart-${id}`] || false;
+  }
+
+  private renderChartView(chart: Chart): TemplateResult {
+    return html`
+      <div class="saved-chart-name">${chart.name}</div>
+      ${this.savedChartDataMap.has(chart.id)
+        ? html`
+            <div class="saved-chart-container">
+              <chart-js
+                type=${chart.config.version === ChartVersion.V2
+                  ? chart.config.type
+                  : ChartConfigType.LINE}
+                .data=${this.savedChartDataMap.get(chart.id)!}
+                label=${chart.name}
+              ></chart-js>
+            </div>
+          `
+        : nothing}
+      <div class="chart-actions">
+        <ss-button
+          @click=${(): void => this.handleEditChart(chart.id)}
+          >${translate('editChart')}</ss-button
+        >
+        <ss-button
+          @click=${(): void => this.handleDeleteChartRequested(chart.id)}
+          >${translate('deleteChart')}</ss-button
+        >
+      </div>
+    `;
+  }
+
+  private renderChartEdit(chart: Chart): TemplateResult {
+    return html`
+      <chart-builder
+        .chart=${chart}
+        @chart-built=${(e: ChartBuiltEvent): Promise<void> => this.handleChartBuilt(e)}
+      ></chart-builder>
+      <div class="chart-actions">
+        <ss-button @click=${(): void => this.handleCancelEdit()}
+          >${translate('cancelEdit')}</ss-button
+        >
+      </div>
+    `;
   }
 
   render(): TemplateResult {
@@ -145,27 +210,9 @@ export class ChartList extends MobxLitElement {
                     this.dispatchEvent(new CollapsableToggledEvent(e.detail));
                   }}
                 >
-                  <div class="saved-chart-name">${chart.name}</div>
-                  ${this.savedChartDataMap.has(chart.id)
-                    ? html`
-                        <div class="saved-chart-container">
-                          <chart-js
-                            type=${chart.config.version === ChartVersion.V2
-                              ? chart.config.type
-                              : ChartConfigType.LINE}
-                            .data=${this.savedChartDataMap.get(chart.id)!}
-                            label=${chart.name}
-                          ></chart-js>
-                        </div>
-                      `
-                    : nothing}
-                  <div class="chart-actions">
-                    <ss-button
-                      @click=${(): void =>
-                        this.handleDeleteChartRequested(chart.id)}
-                      >${translate('deleteChart')}</ss-button
-                    >
-                  </div>
+                  ${this.editingChartId === chart.id
+                    ? this.renderChartEdit(chart)
+                    : this.renderChartView(chart)}
                 </ss-collapsable>
               `,
             )}

--- a/src/components/data-point-builder/data-point-builder.ts
+++ b/src/components/data-point-builder/data-point-builder.ts
@@ -1,4 +1,4 @@
-import { html, css, nothing, TemplateResult } from 'lit';
+import { html, css, nothing, PropertyValues, TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
@@ -41,6 +41,35 @@ export class DataPointBuilder extends MobxLitElement {
   @state() private medalEnd = '';
   @state() private analysisType: AnalysisClassificationType =
     AnalysisClassificationType.MORNING_FASTING;
+
+  updated(changedProperties: PropertyValues): void {
+    if (changedProperties.has(DataPointBuilderProp.DATA_POINT)) {
+      this.initFromDataPoint();
+    }
+  }
+
+  private initFromDataPoint(): void {
+    const dp = this[DataPointBuilderProp.DATA_POINT];
+    if (!dp) {
+      return;
+    }
+    this.operation = dp.operation;
+    if (dp.operation === FactOperation.MEDAL_COUNT) {
+      const ctx = dp as MedalCountFactContext;
+      this.medalConfigId = ctx.medalConfigId;
+      this.series = ctx.series;
+      this.medalStart = ctx.start ?? '';
+      this.medalEnd = ctx.end ?? '';
+    } else if (
+      dp.operation === FactOperation.ENTITY_COUNT ||
+      dp.operation === FactOperation.UNIQUE_TAG_COUNT
+    ) {
+      this.filter = structuredClone(dp.filter);
+    } else if (dp.operation === FactOperation.ANALYSIS_CLASSIFICATION) {
+      this.analysisType = dp.analysisType;
+      this.filter = structuredClone(dp.filter);
+    }
+  }
 
   static styles = css`
     .data-point-builder {

--- a/src/lib/NetworkStorage.ts
+++ b/src/lib/NetworkStorage.ts
@@ -1014,6 +1014,19 @@ export class NetworkStorage implements StorageSchema {
     return [];
   }
 
+  async updateChart(
+    id: number,
+    request: ChartRequest,
+  ): Promise<StorageResult<ChartResponse>> {
+    const result = await api.put<ChartRequest, ChartResponse>(`chart/${id}`, request);
+
+    if (result && result.isOk) {
+      return { isOk: true, value: result.response };
+    }
+
+    return { isOk: false, error: new Error('Failed to update chart') };
+  }
+
   async deleteChart(id: number): Promise<boolean> {
     const result = await api.delete<null>(`chart/${id}`);
 

--- a/src/lib/OfflineCacheStorage.ts
+++ b/src/lib/OfflineCacheStorage.ts
@@ -1299,6 +1299,13 @@ export class OfflineCacheStorage implements StorageSchema {
     return networkStorage.createChart(request);
   }
 
+  async updateChart(
+    id: number,
+    request: ChartRequest,
+  ): Promise<StorageResult<ChartResponse>> {
+    return networkStorage.updateChart(id, request);
+  }
+
   async getCharts(): Promise<Chart[]> {
     return networkStorage.getCharts();
   }

--- a/src/lib/Storage.ts
+++ b/src/lib/Storage.ts
@@ -921,6 +921,14 @@ export class Storage implements StorageSchema {
   }
 
   @delegateSource()
+  async updateChart(
+    _id: number,
+    _request: ChartRequest,
+  ): Promise<StorageResult<ChartResponse>> {
+    return Promise.resolve({ isOk: false, error: new Error('Not implemented') });
+  }
+
+  @delegateSource()
   async getCharts(): Promise<Chart[]> {
     return Promise.resolve([]);
   }

--- a/src/lib/data/localization/en.json
+++ b/src/lib/data/localization/en.json
@@ -516,5 +516,11 @@
   "deleteChart": "Delete Chart",
   "confirmDeleteChart": "Are you sure you want to delete this chart? This action cannot be undone.",
   "chartDeleted": "Chart deleted successfully.",
-  "failedToDeleteChart": "Failed to delete chart."
+  "failedToDeleteChart": "Failed to delete chart.",
+  "editChart": "Edit Chart",
+  "updateChart": "Update Chart",
+  "updating": "Updating...",
+  "failedToUpdateChart": "Failed to update chart.",
+  "chartUpdated": "Chart updated successfully.",
+  "cancelEdit": "Cancel"
 }

--- a/src/models/Storage.ts
+++ b/src/models/Storage.ts
@@ -222,6 +222,7 @@ export interface StorageSchema {
   getActiveWorkspaceId?(): string;
   setActiveWorkspaceId?(id: string): void;
   createChart?(request: ChartRequest): Promise<StorageResult<ChartResponse>>;
+  updateChart?(id: number, request: ChartRequest): Promise<StorageResult<ChartResponse>>;
   getCharts?(): Promise<Chart[]>;
   deleteChart?(id: number): Promise<boolean>;
 }


### PR DESCRIPTION
Closes #186

Adds the ability to edit and update saved charts.

## Changes

- **Storage:** Added `updateChart(id, request)` throughout the storage stack (PUT `chart/:id`)
- **`data-point-builder`:** Now initialises form state from the `data-point` property via `updated()` lifecycle, so existing data points display correctly in edit mode
- **`chart-builder`:** Added `chart` property to pre-populate from an existing chart; "Save Chart" becomes "Update Chart" and calls `updateChart` instead of `createChart`
- **`chart-list`:** Added "Edit Chart" button per chart; clicking it shows an inline `chart-builder` pre-filled with the chart's config; "Cancel" button exits edit mode
- **Localization:** Added `editChart`, `updateChart`, `updating`, `failedToUpdateChart`, `chartUpdated`, `cancelEdit`

Generated with [Claude Code](https://claude.ai/code)