### PR TITLE
Fix: defer optionsOnly blur validation to allow suggestion clicks

### DIFF
--- a/src/components/entity-form/short-text-field/short-text-field.ts
+++ b/src/components/entity-form/short-text-field/short-text-field.ts
@@ -35,6 +35,10 @@ import { SettingName } from 'api-spec/models/Setting';
 
 const minLengthForSuggestion = 1;
 
+// Mirrors the delay ss-input uses before clearing focus state on blur, giving
+// a click on an autocomplete suggestion time to update the value first.
+const blurValidationDelay = 200;
+
 @customElement('short-text-field')
 export class ShortTextField extends MobxLitElement {
   public state = appState;
@@ -172,20 +176,22 @@ export class ShortTextField extends MobxLitElement {
   }
 
   handleInputBlurred(_: InputChangedEvent): void {
-    if (
-      this.propertyConfig.optionsOnly &&
-      this._value.length > 0 &&
-      !this.propertyConfig.options.includes(this._value)
-    ) {
-      addToast(
-        translate('propertyValueNotAllowed', {
-          value: this._value,
-          name: this.propertyConfig.name,
-        }),
-        NotificationType.ERROR,
-      );
-      this.syncValue('');
-    }
+    setTimeout(() => {
+      if (
+        this.propertyConfig.optionsOnly &&
+        this._value.length > 0 &&
+        !this.propertyConfig.options.includes(this._value)
+      ) {
+        addToast(
+          translate('propertyValueNotAllowed', {
+            value: this._value,
+            name: this.propertyConfig.name,
+          }),
+          NotificationType.ERROR,
+        );
+        this.syncValue('');
+      }
+    }, blurValidationDelay);
   }
 
   async focus(): Promise<void> {


### PR DESCRIPTION
## Summary

Clicking an autocomplete suggestion in an `optionsOnly` short-text field produced a "value not allowed" validation error, even though the clicked suggestion is a valid option.

## Root cause

Clicking a suggestion in `ss-input-auto` causes a `mousedown` which blurs the `<input>` (firing `input-blurred` with the stale, partially-typed text) *before* the `click` handler dispatches `suggestion-changed` and updates the value. `short-text-field`'s `optionsOnly` validation ran synchronously on blur, so it rejected the stale text and cleared the field before the suggestion could be applied.

## Fix

Defer the `optionsOnly` blur validation in `short-text-field.ts` by 200ms (matching the delay `ss-input` itself uses after blur), giving a suggestion click time to update the value first.

Closes #193

🤖 Generated with [Claude Code](https://claude.ai/code)