### PR TITLE
feat: show loader while waiting for chart data

### DIFF
--- a/src/components/chart-builder/chart-builder.events.ts
+++ b/src/components/chart-builder/chart-builder.events.ts
@@ -1,6 +1,7 @@
 import { ChartConfigType, ChartResponse } from 'api-spec/models/Statistic';
 
 export const chartBuiltEventName = 'chart-built';
+export const chartGeneratingEventName = 'chart-generating';
 
 export type ChartBuiltPayload = ChartResponse & {
   chartType: `${ChartConfigType}`;
@@ -14,6 +15,16 @@ export class ChartBuiltEvent extends CustomEvent<ChartBuiltPayload> {
       bubbles: true,
       composed: true,
       detail: payload,
+    });
+  }
+}
+
+export class ChartGeneratingEvent extends CustomEvent<Record<string, never>> {
+  constructor() {
+    super(chartGeneratingEventName, {
+      bubbles: true,
+      composed: true,
+      detail: {},
     });
   }
 }

--- a/src/components/chart-builder/chart-builder.ts
+++ b/src/components/chart-builder/chart-builder.ts
@@ -25,7 +25,7 @@ import { InputChangedEvent } from '@ss/ui/components/ss-input.events';
 import { ToggleChangedEvent } from '@ss/ui/components/ss-toggle.events';
 import { DataPointUpdatedEvent } from '@/components/data-point-builder/data-point-builder.events';
 
-import { ChartBuiltEvent } from './chart-builder.events';
+import { ChartBuiltEvent, ChartGeneratingEvent } from './chart-builder.events';
 
 import '@ss/ui/components/ss-select';
 import '@ss/ui/components/ss-input';
@@ -253,6 +253,7 @@ export class ChartBuilder extends MobxLitElement {
 
     this.errorMessage = '';
     this.isLoading = true;
+    this.dispatchEvent(new ChartGeneratingEvent());
 
     const config: ChartConfig = {
       version: ChartVersion.V2,

--- a/src/components/chart-js/chart-js.models.ts
+++ b/src/components/chart-js/chart-js.models.ts
@@ -8,6 +8,7 @@ export enum ChartJsProp {
   DATA = 'data',
   OPTIONS = 'options',
   LABEL = 'label',
+  LOADING = 'loading',
 }
 
 export interface ChartJsProps extends PropTypes {
@@ -15,6 +16,7 @@ export interface ChartJsProps extends PropTypes {
   [ChartJsProp.DATA]: ChartData;
   [ChartJsProp.OPTIONS]: ChartOptions;
   [ChartJsProp.LABEL]: string;
+  [ChartJsProp.LOADING]: boolean;
 }
 
 export const chartJsProps: PropConfigMap<ChartJsProps> = {
@@ -49,5 +51,10 @@ export const chartJsProps: PropConfigMap<ChartJsProps> = {
     default: '',
     control: { type: ControlType.TEXT },
     description: 'Accessible aria-label for the chart canvas',
+  },
+  [ChartJsProp.LOADING]: {
+    default: false,
+    control: { type: ControlType.BOOLEAN },
+    description: 'Shows a loading spinner in place of the chart canvas',
   },
 };

--- a/src/components/chart-js/chart-js.ts
+++ b/src/components/chart-js/chart-js.ts
@@ -9,6 +9,9 @@ import {
   ChartInitializedEvent,
   ChartUpdatedEvent,
 } from './chart-js.events';
+import { translate } from '@/lib/Localization';
+
+import '@/components/svg-icon/svg/svg-spinner';
 
 @customElement('chart-js')
 export class ChartJsElement extends LitElement {
@@ -28,6 +31,10 @@ export class ChartJsElement extends LitElement {
   [ChartJsProp.LABEL]: ChartJsProps[ChartJsProp.LABEL] =
     chartJsProps[ChartJsProp.LABEL].default;
 
+  @property({ type: Boolean })
+  [ChartJsProp.LOADING]: ChartJsProps[ChartJsProp.LOADING] =
+    chartJsProps[ChartJsProp.LOADING].default;
+
   @query('canvas')
   private canvas!: HTMLCanvasElement;
 
@@ -45,6 +52,20 @@ export class ChartJsElement extends LitElement {
     canvas {
       display: block;
     }
+
+    .chart-loader {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 100%;
+      height: 100%;
+    }
+
+    svg-spinner {
+      width: 36px;
+      height: 36px;
+      color: var(--text-color, #333);
+    }
   `;
 
   firstUpdated(): void {
@@ -57,7 +78,19 @@ export class ChartJsElement extends LitElement {
       return;
     }
 
-    if (!this.chart) {
+    if (changedProperties.has(ChartJsProp.LOADING)) {
+      const prevLoading = changedProperties.get(ChartJsProp.LOADING) as
+        | boolean
+        | undefined;
+      if (prevLoading && !this.loading) {
+        this.initChart();
+      } else if (!prevLoading && this.loading) {
+        this.destroyChart();
+      }
+      return;
+    }
+
+    if (this.loading || !this.chart) {
       return;
     }
 
@@ -115,6 +148,14 @@ export class ChartJsElement extends LitElement {
   }
 
   render(): TemplateResult {
+    if (this.loading) {
+      return html`<div
+        class="chart-loader"
+        aria-label=${translate('loadingChart')}
+      >
+        <svg-spinner></svg-spinner>
+      </div>`;
+    }
     return html`<canvas aria-label=${this.label} role="img"></canvas>`;
   }
 }

--- a/src/components/chart-list/chart-list.ts
+++ b/src/components/chart-list/chart-list.ts
@@ -25,6 +25,7 @@ import '@ss/ui/components/ss-button';
 import '@ss/ui/components/confirmation-modal';
 import '@/components/chart-js/chart-js';
 import '@/components/chart-builder/chart-builder';
+import '@/components/svg-icon/svg/svg-spinner';
 
 @customElement('chart-list')
 export class ChartList extends MobxLitElement {
@@ -32,6 +33,7 @@ export class ChartList extends MobxLitElement {
 
   @state() private savedCharts: Chart[] = [];
   @state() private savedChartDataMap: Map<number, ChartData> = new Map();
+  @state() private loadingChartIds: Set<number> = new Set();
   @state() private confirmDeleteChartId: number | null = null;
   @state() private editingChartId: number | null = null;
 
@@ -49,6 +51,20 @@ export class ChartList extends MobxLitElement {
     .no-saved-charts {
       font-style: italic;
       padding: 0.5rem 0;
+    }
+
+    .chart-loader {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 300px;
+      margin-bottom: 0.75rem;
+    }
+
+    svg-spinner {
+      width: 36px;
+      height: 36px;
+      color: var(--text-color, #333);
     }
 
     .chart-actions {
@@ -83,10 +99,14 @@ export class ChartList extends MobxLitElement {
   }
 
   private async loadChartData(chart: Chart): Promise<void> {
+    this.loadingChartIds = new Set([...this.loadingChartIds, chart.id]);
     const result = await storage.createChart?.({
       config: chart.config,
       save: false,
     });
+    const newIds = new Set(this.loadingChartIds);
+    newIds.delete(chart.id);
+    this.loadingChartIds = newIds;
     if (result?.isOk) {
       const newMap = new Map(this.savedChartDataMap);
       newMap.set(chart.id, convertResponseToChartData(result.value));
@@ -141,19 +161,26 @@ export class ChartList extends MobxLitElement {
   private renderChartView(chart: Chart): TemplateResult {
     return html`
       <div class="saved-chart-name">${chart.name}</div>
-      ${this.savedChartDataMap.has(chart.id)
-        ? html`
-            <div class="saved-chart-container">
-              <chart-js
-                type=${chart.config.version === ChartVersion.V2
-                  ? chart.config.type
-                  : ChartConfigType.LINE}
-                .data=${this.savedChartDataMap.get(chart.id)!}
-                label=${chart.name}
-              ></chart-js>
-            </div>
-          `
-        : nothing}
+      ${this.loadingChartIds.has(chart.id)
+        ? html`<div
+            class="chart-loader"
+            aria-label=${translate('loadingChart')}
+          >
+            <svg-spinner></svg-spinner>
+          </div>`
+        : this.savedChartDataMap.has(chart.id)
+          ? html`
+              <div class="saved-chart-container">
+                <chart-js
+                  type=${chart.config.version === ChartVersion.V2
+                    ? chart.config.type
+                    : ChartConfigType.LINE}
+                  .data=${this.savedChartDataMap.get(chart.id)!}
+                  label=${chart.name}
+                ></chart-js>
+              </div>
+            `
+          : nothing}
       <div class="chart-actions">
         <ss-button
           @click=${(): void => this.handleEditChart(chart.id)}

--- a/src/components/chart-list/chart-list.ts
+++ b/src/components/chart-list/chart-list.ts
@@ -25,7 +25,6 @@ import '@ss/ui/components/ss-button';
 import '@ss/ui/components/confirmation-modal';
 import '@/components/chart-js/chart-js';
 import '@/components/chart-builder/chart-builder';
-import '@/components/svg-icon/svg/svg-spinner';
 
 @customElement('chart-list')
 export class ChartList extends MobxLitElement {
@@ -51,20 +50,6 @@ export class ChartList extends MobxLitElement {
     .no-saved-charts {
       font-style: italic;
       padding: 0.5rem 0;
-    }
-
-    .chart-loader {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 300px;
-      margin-bottom: 0.75rem;
-    }
-
-    svg-spinner {
-      width: 36px;
-      height: 36px;
-      color: var(--text-color, #333);
     }
 
     .chart-actions {
@@ -159,28 +144,24 @@ export class ChartList extends MobxLitElement {
   }
 
   private renderChartView(chart: Chart): TemplateResult {
+    const isLoading = this.loadingChartIds.has(chart.id);
     return html`
       <div class="saved-chart-name">${chart.name}</div>
-      ${this.loadingChartIds.has(chart.id)
-        ? html`<div
-            class="chart-loader"
-            aria-label=${translate('loadingChart')}
-          >
-            <svg-spinner></svg-spinner>
-          </div>`
-        : this.savedChartDataMap.has(chart.id)
-          ? html`
-              <div class="saved-chart-container">
-                <chart-js
-                  type=${chart.config.version === ChartVersion.V2
-                    ? chart.config.type
-                    : ChartConfigType.LINE}
-                  .data=${this.savedChartDataMap.get(chart.id)!}
-                  label=${chart.name}
-                ></chart-js>
-              </div>
-            `
-          : nothing}
+      ${isLoading || this.savedChartDataMap.has(chart.id)
+        ? html`
+            <div class="saved-chart-container">
+              <chart-js
+                type=${chart.config.version === ChartVersion.V2
+                  ? chart.config.type
+                  : ChartConfigType.LINE}
+                .data=${this.savedChartDataMap.get(chart.id) ??
+                { labels: [], datasets: [] }}
+                ?loading=${isLoading}
+                label=${chart.name}
+              ></chart-js>
+            </div>
+          `
+        : nothing}
       <div class="chart-actions">
         <ss-button
           @click=${(): void => this.handleEditChart(chart.id)}

--- a/src/components/user-dashboard/user-dashboard.ts
+++ b/src/components/user-dashboard/user-dashboard.ts
@@ -27,6 +27,7 @@ export class UserDashboard extends MobxLitElement {
 
   @state() private savedCharts: Chart[] = [];
   @state() private chartDataMap: Map<number, ChartData> = new Map();
+  @state() private loadingChartIds: Set<number> = new Set();
 
   static styles = css`
     .user-dashboard {
@@ -117,10 +118,14 @@ export class UserDashboard extends MobxLitElement {
   }
 
   private async loadChartData(chart: Chart): Promise<void> {
+    this.loadingChartIds = new Set([...this.loadingChartIds, chart.id]);
     const result = await storage.createChart?.({
       config: chart.config,
       save: false,
     });
+    const newIds = new Set(this.loadingChartIds);
+    newIds.delete(chart.id);
+    this.loadingChartIds = newIds;
     if (result?.isOk) {
       const newMap = new Map(this.chartDataMap);
       newMap.set(chart.id, this.convertResponseToChartData(result.value));
@@ -156,24 +161,29 @@ export class UserDashboard extends MobxLitElement {
           ${repeat(
             this.savedCharts,
             chart => chart.id,
-            chart => html`
-              <div class="chart-container">
-                <h3 class="chart-title">${chart.name}</h3>
-                ${this.chartDataMap.has(chart.id)
-                  ? html`
-                      <div class="chart-wrapper">
-                        <chart-js
-                          type=${chart.config.version === ChartVersion.V2
-                            ? chart.config.type
-                            : ChartConfigType.LINE}
-                          .data=${this.chartDataMap.get(chart.id)!}
-                          label=${chart.name}
-                        ></chart-js>
-                      </div>
-                    `
-                  : nothing}
-              </div>
-            `,
+            chart => {
+              const isLoading = this.loadingChartIds.has(chart.id);
+              return html`
+                <div class="chart-container">
+                  <h3 class="chart-title">${chart.name}</h3>
+                  ${isLoading || this.chartDataMap.has(chart.id)
+                    ? html`
+                        <div class="chart-wrapper">
+                          <chart-js
+                            type=${chart.config.version === ChartVersion.V2
+                              ? chart.config.type
+                              : ChartConfigType.LINE}
+                            .data=${this.chartDataMap.get(chart.id) ??
+                            { labels: [], datasets: [] }}
+                            ?loading=${isLoading}
+                            label=${chart.name}
+                          ></chart-js>
+                        </div>
+                      `
+                    : nothing}
+                </div>
+              `;
+            },
           )}
         </div>
       </div>

--- a/src/lib/data/localization/en.json
+++ b/src/lib/data/localization/en.json
@@ -526,6 +526,7 @@
   "chartType.radar": "Radar",
   "generateChart": "Generate Chart",
   "generating": "Generating...",
+  "loadingChart": "Loading chart...",
   "failedToGenerateChart": "Failed to generate chart.",
   "saveChart": "Save Chart",
   "saving": "Saving...",

--- a/src/views/chart-view/chart-view.ts
+++ b/src/views/chart-view/chart-view.ts
@@ -8,7 +8,10 @@ import { translate } from '@/lib/Localization';
 import { ViewElement } from '@/lib/ViewElement';
 import { appState } from '@/state';
 import { convertResponseToChartData } from '@/lib/ChartUtil';
-import { ChartBuiltEvent } from '@/components/chart-builder/chart-builder.events';
+import {
+  ChartBuiltEvent,
+  ChartGeneratingEvent,
+} from '@/components/chart-builder/chart-builder.events';
 import { ChartList } from '@/components/chart-list/chart-list';
 
 import '@/components/user-header/user-header';
@@ -16,6 +19,7 @@ import '@/components/login-form/login-form';
 import '@/components/chart-builder/chart-builder';
 import '@/components/chart-js/chart-js';
 import '@/components/chart-list/chart-list';
+import '@/components/svg-icon/svg/svg-spinner';
 
 @customElement('chart-view')
 export class ChartView extends ViewElement {
@@ -24,6 +28,7 @@ export class ChartView extends ViewElement {
   @state() private chartData: ChartData = { labels: [], datasets: [] };
   @state() private chartType: `${ChartConfigType}` = ChartConfigType.LINE;
   @state() private hasChart = false;
+  @state() private isChartLoading = false;
 
   @query('chart-list') private chartList: ChartList | undefined;
 
@@ -36,6 +41,20 @@ export class ChartView extends ViewElement {
     .chart-container {
       margin-top: 1.5rem;
       height: 400px;
+    }
+
+    .chart-loader {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-top: 1.5rem;
+      height: 400px;
+    }
+
+    svg-spinner {
+      width: 36px;
+      height: 36px;
+      color: var(--text-color, #333);
     }
   `;
 
@@ -51,7 +70,11 @@ export class ChartView extends ViewElement {
       <user-header></user-header>
       <div class="view-content">
         <chart-builder
+          @chart-generating=${(_e: ChartGeneratingEvent): void => {
+            this.isChartLoading = true;
+          }}
           @chart-built=${(e: ChartBuiltEvent): void => {
+            this.isChartLoading = false;
             this.chartData = convertResponseToChartData(e.detail);
             this.chartType = e.detail.chartType;
             this.hasChart = true;
@@ -60,17 +83,24 @@ export class ChartView extends ViewElement {
             }
           }}
         ></chart-builder>
-        ${this.hasChart
-          ? html`
-              <div class="chart-container">
-                <chart-js
-                  type=${this.chartType}
-                  .data=${this.chartData}
-                  label=${translate('chartLabel')}
-                ></chart-js>
-              </div>
-            `
-          : nothing}
+        ${this.isChartLoading
+          ? html`<div
+              class="chart-loader"
+              aria-label=${translate('loadingChart')}
+            >
+              <svg-spinner></svg-spinner>
+            </div>`
+          : this.hasChart
+            ? html`
+                <div class="chart-container">
+                  <chart-js
+                    type=${this.chartType}
+                    .data=${this.chartData}
+                    label=${translate('chartLabel')}
+                  ></chart-js>
+                </div>
+              `
+            : nothing}
         <chart-list></chart-list>
       </div>
     `;

--- a/src/views/chart-view/chart-view.ts
+++ b/src/views/chart-view/chart-view.ts
@@ -19,7 +19,6 @@ import '@/components/login-form/login-form';
 import '@/components/chart-builder/chart-builder';
 import '@/components/chart-js/chart-js';
 import '@/components/chart-list/chart-list';
-import '@/components/svg-icon/svg/svg-spinner';
 
 @customElement('chart-view')
 export class ChartView extends ViewElement {
@@ -41,20 +40,6 @@ export class ChartView extends ViewElement {
     .chart-container {
       margin-top: 1.5rem;
       height: 400px;
-    }
-
-    .chart-loader {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      margin-top: 1.5rem;
-      height: 400px;
-    }
-
-    svg-spinner {
-      width: 36px;
-      height: 36px;
-      color: var(--text-color, #333);
     }
   `;
 
@@ -83,24 +68,18 @@ export class ChartView extends ViewElement {
             }
           }}
         ></chart-builder>
-        ${this.isChartLoading
-          ? html`<div
-              class="chart-loader"
-              aria-label=${translate('loadingChart')}
-            >
-              <svg-spinner></svg-spinner>
-            </div>`
-          : this.hasChart
-            ? html`
-                <div class="chart-container">
-                  <chart-js
-                    type=${this.chartType}
-                    .data=${this.chartData}
-                    label=${translate('chartLabel')}
-                  ></chart-js>
-                </div>
-              `
-            : nothing}
+        ${this.isChartLoading || this.hasChart
+          ? html`
+              <div class="chart-container">
+                <chart-js
+                  type=${this.chartType}
+                  .data=${this.chartData}
+                  ?loading=${this.isChartLoading}
+                  label=${translate('chartLabel')}
+                ></chart-js>
+              </div>
+            `
+          : nothing}
         <chart-list></chart-list>
       </div>
     `;


### PR DESCRIPTION
Add spinner indicators in chart-view and chart-list while chart data is being fetched, improving UX during slow AI-driven chart generation.

- Add ChartGeneratingEvent dispatched when chart-builder starts loading
- chart-view listens for the event and shows a spinner in the chart area
- chart-list tracks per-chart loading state and shows a spinner per saved chart
- Add loadingChart localization key

Closes #195

Generated with [Claude Code](https://claude.ai/code)