### PR TITLE
feat: add support for propertySum fact type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@adobe/lit-mobx": "^2.2.2",
         "@sqlite.org/sqlite-wasm": "^3.51.2-build8",
         "@ss/ui": "github:SikoSoft/ui#2.26.2",
-        "api-spec": "github:SikoSoft/api-spec#1.108.0",
+        "api-spec": "github:SikoSoft/api-spec#1.112.0",
         "chart.js": "^4.5.1",
         "dompurify": "^3.3.1",
         "file-saver": "^2.0.5",
@@ -2295,8 +2295,8 @@
       }
     },
     "node_modules/api-spec": {
-      "version": "1.108.0",
-      "resolved": "git+ssh://git@github.com/SikoSoft/api-spec.git#99e910119727f8a1413a20cfed90e50536c0bf5a",
+      "version": "1.112.0",
+      "resolved": "git+ssh://git@github.com/SikoSoft/api-spec.git#56dab3e97e4048b2b4b8196f818651a52c752932",
       "license": "ISC"
     },
     "node_modules/argparse": {
@@ -5462,9 +5462,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@adobe/lit-mobx": "^2.2.2",
     "@sqlite.org/sqlite-wasm": "^3.51.2-build8",
     "@ss/ui": "github:SikoSoft/ui#2.26.2",
-    "api-spec": "github:SikoSoft/api-spec#1.108.0",
+    "api-spec": "github:SikoSoft/api-spec#1.112.0",
     "chart.js": "^4.5.1",
     "dompurify": "^3.3.1",
     "file-saver": "^2.0.5",

--- a/src/components/collection-wizard/collection-wizard.ts
+++ b/src/components/collection-wizard/collection-wizard.ts
@@ -171,6 +171,7 @@ export class CollectionWizard extends MobxLitElement {
           allowPropertyOrdering: entityConfig.allowPropertyOrdering,
           allowTags: entityConfig.allowTags,
           aiEnabled: entityConfig.aiEnabled,
+          aiClassifyEnabled: false,
           aiIdentifyPrompt: entityConfig.aiIdentifyPrompt,
           public: entityConfig.public ?? false,
           viewAccessPolicy: null,

--- a/src/components/data-point-builder/data-point-builder.ts
+++ b/src/components/data-point-builder/data-point-builder.ts
@@ -7,11 +7,13 @@ import {
   FactContext,
   FactOperation,
   MedalCountFactContext,
+  PropertySumFactContext,
 } from 'api-spec/models/Fact';
+import { DataType } from 'api-spec/models/Entity';
 import { ListFilter as ListFilterSpec } from 'api-spec/models/List';
 
 import { translate } from '@/lib/Localization';
-import { defaultListFilter } from '@/state';
+import { appState, defaultListFilter } from '@/state';
 import { SelectChangedEvent } from '@ss/ui/components/ss-select.events';
 import { InputChangedEvent } from '@ss/ui/components/ss-input.events';
 import { ListFilterUpdatedEvent } from '@/components/list-filter/list-filter.events';
@@ -41,6 +43,7 @@ export class DataPointBuilder extends MobxLitElement {
   @state() private medalEnd = '';
   @state() private analysisType: AnalysisClassificationType =
     AnalysisClassificationType.MORNING_FASTING;
+  @state() private propertyConfigId = 0;
 
   updated(changedProperties: PropertyValues): void {
     if (changedProperties.has(DataPointBuilderProp.DATA_POINT)) {
@@ -68,6 +71,10 @@ export class DataPointBuilder extends MobxLitElement {
     } else if (dp.operation === FactOperation.ANALYSIS_CLASSIFICATION) {
       this.analysisType = dp.analysisType;
       this.filter = structuredClone(dp.filter);
+    } else if (dp.operation === FactOperation.PROPERTY_SUM) {
+      const ctx = dp as PropertySumFactContext;
+      this.filter = structuredClone(ctx.filter);
+      this.propertyConfigId = ctx.propertyConfigId;
     }
   }
 
@@ -118,11 +125,36 @@ export class DataPointBuilder extends MobxLitElement {
           filter: this.filter,
           analysisType: this.analysisType,
         };
+      case FactOperation.PROPERTY_SUM:
+        return {
+          operation: FactOperation.PROPERTY_SUM,
+          filter: this.filter,
+          propertyConfigId: this.propertyConfigId,
+        };
     }
   }
 
   private emitUpdate(): void {
     this.dispatchEvent(new DataPointUpdatedEvent(this.buildFactContext()));
+  }
+
+  private getIntPropertyOptions(): { value: string; label: string }[] {
+    const types = this.filter.includeTypes ?? [];
+    const configs =
+      types.length > 0
+        ? appState.entityConfigs.filter(c => types.includes(c.id))
+        : appState.entityConfigs;
+    const seen = new Set<number>();
+    const options: { value: string; label: string }[] = [];
+    for (const config of configs) {
+      for (const property of config.properties) {
+        if (property.dataType === DataType.INT && !seen.has(property.id)) {
+          seen.add(property.id);
+          options.push({ value: String(property.id), label: property.name });
+        }
+      }
+    }
+    return options;
   }
 
   private renderFilterField(): TemplateResult {
@@ -210,6 +242,21 @@ export class DataPointBuilder extends MobxLitElement {
             ></ss-select>
           </div>
           ${this.renderFilterField()}
+        `;
+      case FactOperation.PROPERTY_SUM:
+        return html`
+          ${this.renderFilterField()}
+          <div class="field">
+            <label>${translate('propertyConfigId')}</label>
+            <ss-select
+              selected=${String(this.propertyConfigId)}
+              .options=${this.getIntPropertyOptions()}
+              @select-changed=${(e: SelectChangedEvent<string>): void => {
+                this.propertyConfigId = parseInt(e.detail.value) || 0;
+                this.emitUpdate();
+              }}
+            ></ss-select>
+          </div>
         `;
       default:
         return html`${nothing}`;

--- a/src/components/entity-config-form/entity-config-form.ts
+++ b/src/components/entity-config-form/entity-config-form.ts
@@ -250,6 +250,7 @@ export class EntityConfigForm extends MobxLitElement {
       allowPropertyOrdering: this[EntityConfigFormProp.ALLOW_PROPERTY_ORDERING],
       allowTags: this[EntityConfigFormProp.ALLOW_TAGS],
       aiEnabled: this[EntityConfigFormProp.AI_ENABLED],
+      aiClassifyEnabled: false,
       aiIdentifyPrompt: this[EntityConfigFormProp.AI_IDENTIFY_PROMPT],
       viewAccessPolicy: this[EntityConfigFormProp.VIEW_ACCESS_POLICY],
       editAccessPolicy: this[EntityConfigFormProp.EDIT_ACCESS_POLICY],

--- a/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
+++ b/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
@@ -10,10 +10,13 @@ import {
   MedalCountFactContext,
   AnalysisClassificationFactContext,
   AnalysisClassificationType,
+  PropertySumFactContext,
 } from 'api-spec/models/Fact';
+import { DataType } from 'api-spec/models/Entity';
 import { defaultListFilter } from 'api-spec/models/List';
 
 import { translate } from '@/lib/Localization';
+import { appState } from '@/state';
 import { SelectChangedEvent } from '@ss/ui/components/ss-select.events';
 import { InputChangedEvent } from '@ss/ui/components/ss-input.events';
 import { themed } from '@/lib/Theme';
@@ -36,6 +39,7 @@ const operationOptions = [
   { value: FactOperation.UNIQUE_TAG_COUNT, label: translate('factOperation.uniqueTagCount') },
   { value: FactOperation.MEDAL_COUNT, label: translate('factOperation.medalCount') },
   { value: FactOperation.ANALYSIS_CLASSIFICATION, label: translate('factOperation.analysisClassification') },
+  { value: FactOperation.PROPERTY_SUM, label: translate('factOperation.propertySum') },
 ];
 
 @themed()
@@ -103,8 +107,28 @@ export class FactRequestEditor extends MobxLitElement {
     );
   }
 
+  private getIntPropertyOptions(
+    includeTypes: number[],
+  ): { value: string; label: string }[] {
+    const configs =
+      includeTypes.length > 0
+        ? appState.entityConfigs.filter(c => includeTypes.includes(c.id))
+        : appState.entityConfigs;
+    const seen = new Set<number>();
+    const options: { value: string; label: string }[] = [];
+    for (const config of configs) {
+      for (const property of config.properties) {
+        if (property.dataType === DataType.INT && !seen.has(property.id)) {
+          seen.add(property.id);
+          options.push({ value: String(property.id), label: property.name });
+        }
+      }
+    }
+    return options;
+  }
+
   private renderFilterButton(
-    context: EntityCountFactContext | UniqueTagCountFactContext | AnalysisClassificationFactContext,
+    context: EntityCountFactContext | UniqueTagCountFactContext | AnalysisClassificationFactContext | PropertySumFactContext,
     fr: FactRequest,
   ): TemplateResult {
     return html`
@@ -140,6 +164,35 @@ export class FactRequestEditor extends MobxLitElement {
                 this.emit({
                   ...fr,
                   context: { ...context, analysisType: e.detail.value as AnalysisClassificationType },
+                });
+              }}
+            ></ss-select>
+          </div>
+        </div>
+      </div>
+      ${this.renderFilterButton(context, fr)}
+    `;
+  }
+
+  private renderPropertySumFields(
+    context: PropertySumFactContext,
+    fr: FactRequest,
+  ): TemplateResult {
+    return html`
+      <div class="context-fields">
+        <div class="row">
+          <div class="field">
+            <label>${translate('propertyConfigId')}</label>
+            <ss-select
+              .options=${this.getIntPropertyOptions(context.filter.includeTypes ?? [])}
+              .selected=${String(context.propertyConfigId)}
+              @select-changed=${(e: SelectChangedEvent<string>): void => {
+                this.emit({
+                  ...fr,
+                  context: {
+                    ...context,
+                    propertyConfigId: Number(e.detail.value),
+                  },
                 });
               }}
             ></ss-select>
@@ -205,6 +258,8 @@ export class FactRequestEditor extends MobxLitElement {
                 newContext = { operation: op, medalConfigId: 0, series: '' };
               } else if (op === FactOperation.ANALYSIS_CLASSIFICATION) {
                 newContext = { operation: op, filter: { ...defaultListFilter }, analysisType: AnalysisClassificationType.MORNING_FASTING };
+              } else if (op === FactOperation.PROPERTY_SUM) {
+                newContext = { operation: op, filter: { ...defaultListFilter }, propertyConfigId: 0 };
               } else {
                 newContext = { operation: op, filter: { ...defaultListFilter } };
               }
@@ -234,6 +289,9 @@ export class FactRequestEditor extends MobxLitElement {
             fr.context as AnalysisClassificationFactContext,
             fr,
           )
+        : nothing}
+      ${operation === FactOperation.PROPERTY_SUM
+        ? this.renderPropertySumFields(fr.context as PropertySumFactContext, fr)
         : nothing}
     `;
   }

--- a/src/components/medal-config-form/streak-request-editor/streak-request-editor.ts
+++ b/src/components/medal-config-form/streak-request-editor/streak-request-editor.ts
@@ -291,6 +291,8 @@ export class StreakRequestEditor extends MobxLitElement {
                   newInnerContext = { operation: op, medalConfigId: 0, series: '' };
                 } else if (op === FactOperation.ANALYSIS_CLASSIFICATION) {
                   newInnerContext = { operation: op, filter: { ...defaultListFilter }, analysisType: AnalysisClassificationType.MORNING_FASTING };
+                } else if (op === FactOperation.PROPERTY_SUM) {
+                  newInnerContext = { operation: op, filter: { ...defaultListFilter }, propertyConfigId: 0 };
                 } else {
                   newInnerContext = { operation: op, filter: { ...defaultListFilter } };
                 }

--- a/src/lib/SQLiteStorage.ts
+++ b/src/lib/SQLiteStorage.ts
@@ -100,6 +100,7 @@ function rowToEntityConfig(row: Record<string, unknown>): EntityConfig {
     allowPropertyOrdering: row['allow_property_ordering'] === 1,
     allowTags: row['allow_tags'] === 1,
     aiEnabled: row['ai_enabled'] === 1,
+    aiClassifyEnabled: row['ai_classify_enabled'] === 1,
     aiIdentifyPrompt: (row['ai_identify_prompt'] as string | null) ?? '',
     public: row['public'] === 1,
     viewAccessPolicy: null,

--- a/src/lib/data/localization/en.json
+++ b/src/lib/data/localization/en.json
@@ -510,6 +510,8 @@
   "factOperation.uniqueTagCount": "Unique Tag Count",
   "factOperation.medalCount": "Medal Count",
   "factOperation.analysisClassification": "Analysis Classification",
+  "factOperation.propertySum": "Property Sum",
+  "propertyConfigId": "Property",
   "analysisType": "Analysis Type",
   "analysisType.morningFasting": "Morning Fasting",
   "analysisType.afternoonSnacking": "Afternoon Snacking",

--- a/src/tests/unit/state.test.ts
+++ b/src/tests/unit/state.test.ts
@@ -162,6 +162,7 @@ describe('AppState', () => {
         allowPropertyOrdering: false,
         allowTags: true,
         aiEnabled: false,
+        aiClassifyEnabled: false,
         aiIdentifyPrompt: '',
         public: false,
         viewAccessPolicy: null,


### PR DESCRIPTION
Update api-spec to 1.112.0 and add support for the `propertySum` fact type in the chart builder interface.

## Changes

- Updated api-spec dependency to 1.112.0 (adds `FactOperation.PROPERTY_SUM` and `PropertySumFactContext`)
- `data-point-builder`: new operation renders a filter control + a dropdown of all int-typed properties from entity configs matching the filter's selected types
- `fact-request-editor`: same treatment for the medal config fact request editor
- `streak-request-editor`: handle PROPERTY_SUM in operation switch
- Added localization keys for `factOperation.propertySum` and `propertyConfigId`
- Fixed `aiClassifyEnabled` missing-field TypeScript errors introduced by the api-spec bump

Closes #200

Generated with [Claude Code](https://claude.ai/code)