### PR TITLE
feat: implement savable facts feature (#203)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@adobe/lit-mobx": "^2.2.2",
     "@sqlite.org/sqlite-wasm": "^3.51.2-build8",
     "@ss/ui": "github:SikoSoft/ui#2.26.2",
-    "api-spec": "github:SikoSoft/api-spec#1.116.0",
+    "api-spec": "github:SikoSoft/api-spec#1.118.0",
     "chart.js": "^4.5.1",
     "dompurify": "^3.3.1",
     "file-saver": "^2.0.5",

--- a/src/components/fact-card/fact-card.models.ts
+++ b/src/components/fact-card/fact-card.models.ts
@@ -1,0 +1,27 @@
+import { Fact, FactResult } from 'api-spec/models/Fact';
+
+import { ControlType } from '@/models/Control';
+import { PropConfigMap, PropTypes } from '@/models/Prop';
+
+export enum FactCardProp {
+  FACT = 'fact',
+  RESULT = 'result',
+}
+
+export interface FactCardProps extends PropTypes {
+  [FactCardProp.FACT]: Fact | null;
+  [FactCardProp.RESULT]: FactResult | null;
+}
+
+export const factCardProps: PropConfigMap<FactCardProps> = {
+  [FactCardProp.FACT]: {
+    default: null,
+    description: 'The fact to display',
+    control: { type: ControlType.HIDDEN },
+  },
+  [FactCardProp.RESULT]: {
+    default: null,
+    description: 'The computed fact result',
+    control: { type: ControlType.HIDDEN },
+  },
+};

--- a/src/components/fact-card/fact-card.ts
+++ b/src/components/fact-card/fact-card.ts
@@ -1,0 +1,116 @@
+import { LitElement, css, html, nothing, TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import { translate } from '@/lib/Localization';
+import { IconName } from '@/components/svg-icon/svg-icon.models';
+import '@/components/svg-icon/svg-icon';
+
+import { FactCardProp, FactCardProps, factCardProps } from './fact-card.models';
+
+@customElement('fact-card')
+export class FactCard extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .card {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 0.5rem;
+      padding: 1.5rem 1rem 1.25rem;
+      border: 2px solid var(--border-color, #ccc);
+      border-top: 3px solid var(--primary-color, #0066ff);
+      border-radius: var(--border-radius, 0.5rem);
+      background: var(--box-background-color, #fff);
+      color: var(--box-text-color, var(--text-color, inherit));
+    }
+
+    .icon-badge {
+      width: 3rem;
+      height: 3rem;
+      border-radius: 50%;
+      background: color-mix(in srgb, var(--primary-color, #0066ff) 12%, transparent);
+      border: 2px solid color-mix(in srgb, var(--primary-color, #0066ff) 35%, transparent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--primary-color, #0066ff);
+      margin-bottom: 0.25rem;
+    }
+
+    .name {
+      font-size: 0.9375rem;
+      font-weight: 600;
+      margin: 0;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .divider {
+      width: 2rem;
+      height: 2px;
+      background: color-mix(in srgb, var(--primary-color, #0066ff) 30%, transparent);
+      border-radius: 1px;
+      margin: 0.375rem 0;
+    }
+
+    .stat-value {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.125rem;
+    }
+
+    .stat-label {
+      font-size: 0.625rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    .stat-number {
+      font-size: 2.75rem;
+      font-weight: 700;
+      line-height: 1;
+      color: var(--primary-color, #0066ff);
+    }
+  `;
+
+  @property({ type: Object })
+  [FactCardProp.FACT]: FactCardProps[FactCardProp.FACT] =
+    factCardProps[FactCardProp.FACT].default;
+
+  @property({ type: Object })
+  [FactCardProp.RESULT]: FactCardProps[FactCardProp.RESULT] =
+    factCardProps[FactCardProp.RESULT].default;
+
+  render(): TemplateResult | typeof nothing {
+    const fact = this[FactCardProp.FACT];
+    const result = this[FactCardProp.RESULT];
+
+    if (!fact) {
+      return nothing;
+    }
+
+    const value = result?.value ?? 0;
+
+    return html`
+      <div class="card">
+        <div class="icon-badge">
+          <svg-icon .name=${IconName.CHARTS} .size=${22}></svg-icon>
+        </div>
+        <p class="name">${fact.name}</p>
+        <div class="divider"></div>
+        <div class="stat-value">
+          <span class="stat-label">${translate('factValue')}</span>
+          <span class="stat-number">${value}</span>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/components/fact-config-form/fact-config-form.events.ts
+++ b/src/components/fact-config-form/fact-config-form.events.ts
@@ -1,0 +1,13 @@
+import { Fact } from 'api-spec/models/Fact';
+
+export const factSavedEventName = 'fact-saved';
+
+export interface FactSavedPayload {
+  fact: Fact;
+}
+
+export class FactSavedEvent extends CustomEvent<FactSavedPayload> {
+  constructor(detail: FactSavedPayload) {
+    super(factSavedEventName, { detail, bubbles: true, composed: true });
+  }
+}

--- a/src/components/fact-config-form/fact-config-form.models.ts
+++ b/src/components/fact-config-form/fact-config-form.models.ts
@@ -1,0 +1,19 @@
+import { ControlType } from '@/models/Control';
+import { PropConfigMap, PropTypes } from '@/models/Prop';
+import { Fact } from 'api-spec/models/Fact';
+
+export enum FactConfigFormProp {
+  FACT = 'fact',
+}
+
+export interface FactConfigFormProps extends PropTypes {
+  [FactConfigFormProp.FACT]: Fact | null;
+}
+
+export const factConfigFormProps: PropConfigMap<FactConfigFormProps> = {
+  [FactConfigFormProp.FACT]: {
+    default: null,
+    description: 'The existing fact to edit, or null to create a new one',
+    control: { type: ControlType.HIDDEN },
+  },
+};

--- a/src/components/fact-config-form/fact-config-form.ts
+++ b/src/components/fact-config-form/fact-config-form.ts
@@ -1,0 +1,142 @@
+import { html, css, TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+
+import { NotificationType } from '@ss/ui/components/notification-provider.models';
+
+import { translate } from '@/lib/Localization';
+import { storage } from '@/lib/Storage';
+import { addToast } from '@/lib/Util';
+import { InputChangedEvent } from '@ss/ui/components/ss-input.events';
+import { themed } from '@/lib/Theme';
+
+import {
+  FactConfigFormProp,
+  factConfigFormProps,
+  FactConfigFormProps,
+} from './fact-config-form.models';
+import { FactSavedEvent } from './fact-config-form.events';
+import { defaultFactContext } from '@/components/fact-form/fact-form.models';
+import { FactContextChangedEvent } from '@/components/fact-form/fact-form.events';
+
+import '@ss/ui/components/ss-input';
+import '@ss/ui/components/ss-button';
+import '@/components/fact-form/fact-form';
+
+@themed()
+@customElement('fact-config-form')
+export class FactConfigForm extends MobxLitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .row {
+      display: flex;
+      gap: 0.75rem;
+      align-items: flex-end;
+      margin-bottom: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      gap: 0.25rem;
+      min-width: 8rem;
+    }
+
+    .field label {
+      font-size: 0.8125rem;
+      font-weight: bold;
+    }
+
+    .buttons {
+      margin-top: 0.75rem;
+    }
+  `;
+
+  @property({ type: Object })
+  [FactConfigFormProp.FACT]: FactConfigFormProps[FactConfigFormProp.FACT] =
+    factConfigFormProps[FactConfigFormProp.FACT].default;
+
+  @state() private factName = '';
+  @state() private localContext = defaultFactContext();
+  @state() private isSaving = false;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    const fact = this[FactConfigFormProp.FACT];
+    if (fact) {
+      this.factName = fact.name;
+      this.localContext = { ...fact.context };
+    }
+  }
+
+  private async handleSave(): Promise<void> {
+    if (!this.factName.trim()) {
+      addToast(translate('factNameRequired'), NotificationType.ERROR);
+      return;
+    }
+
+    this.isSaving = true;
+
+    const fact = this[FactConfigFormProp.FACT];
+    let result;
+
+    if (fact) {
+      result = await storage.updateFact?.(fact.id, this.factName, this.localContext);
+    } else {
+      result = await storage.createFact?.(this.factName, this.localContext);
+    }
+
+    this.isSaving = false;
+
+    if (!result || !result.isOk) {
+      addToast(translate('failedToSaveFact'), NotificationType.ERROR);
+      return;
+    }
+
+    addToast(translate('factSaved'), NotificationType.SUCCESS);
+    this.dispatchEvent(new FactSavedEvent({ fact: result.value }));
+
+    if (!fact) {
+      this.factName = '';
+      this.localContext = defaultFactContext();
+    }
+  }
+
+  render(): TemplateResult {
+    return html`
+      <div class="row">
+        <div class="field">
+          <label>${translate('name')}</label>
+          <ss-input
+            .value=${this.factName}
+            @input-changed=${(e: InputChangedEvent): void => {
+              this.factName = e.detail.value;
+            }}
+          ></ss-input>
+        </div>
+      </div>
+
+      <fact-form
+        .context=${this.localContext}
+        @fact-context-changed=${(e: FactContextChangedEvent): void => {
+          this.localContext = e.detail.context;
+        }}
+      ></fact-form>
+
+      <div class="buttons">
+        <ss-button
+          positive
+          ?disabled=${this.isSaving}
+          @click=${this.handleSave}
+        >
+          ${translate(this[FactConfigFormProp.FACT] ? 'update' : 'create')}
+        </ss-button>
+      </div>
+    `;
+  }
+}

--- a/src/components/fact-form/fact-form.events.ts
+++ b/src/components/fact-form/fact-form.events.ts
@@ -1,0 +1,13 @@
+import { FactContext } from 'api-spec/models/Fact';
+
+export const factContextChangedEventName = 'fact-context-changed';
+
+export interface FactContextChangedPayload {
+  context: FactContext;
+}
+
+export class FactContextChangedEvent extends CustomEvent<FactContextChangedPayload> {
+  constructor(detail: FactContextChangedPayload) {
+    super(factContextChangedEventName, { detail, bubbles: true, composed: true });
+  }
+}

--- a/src/components/fact-form/fact-form.models.ts
+++ b/src/components/fact-form/fact-form.models.ts
@@ -1,0 +1,28 @@
+import { FactContext, FactOperation } from 'api-spec/models/Fact';
+import { defaultListFilter } from 'api-spec/models/List';
+
+import { ControlType } from '@/models/Control';
+import { PropConfigMap, PropTypes } from '@/models/Prop';
+
+export enum FactFormProp {
+  CONTEXT = 'context',
+}
+
+export interface FactFormProps extends PropTypes {
+  [FactFormProp.CONTEXT]: FactContext;
+}
+
+export function defaultFactContext(): FactContext {
+  return {
+    operation: FactOperation.ENTITY_COUNT,
+    filter: { ...defaultListFilter },
+  };
+}
+
+export const factFormProps: PropConfigMap<FactFormProps> = {
+  [FactFormProp.CONTEXT]: {
+    default: defaultFactContext(),
+    description: 'The fact context being configured',
+    control: { type: ControlType.HIDDEN },
+  },
+};

--- a/src/components/fact-form/fact-form.ts
+++ b/src/components/fact-form/fact-form.ts
@@ -1,0 +1,252 @@
+import { html, css, nothing, TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+
+import {
+  FactContext,
+  FactOperation,
+  AnalysisClassificationType,
+  EntityCountFactContext,
+  UniqueTagCountFactContext,
+  MedalCountFactContext,
+  AnalysisClassificationFactContext,
+  PropertySumFactContext,
+} from 'api-spec/models/Fact';
+import { DataType } from 'api-spec/models/Entity';
+import { defaultListFilter } from 'api-spec/models/List';
+
+import { translate } from '@/lib/Localization';
+import { appState } from '@/state';
+import { SelectChangedEvent } from '@ss/ui/components/ss-select.events';
+import { InputChangedEvent } from '@ss/ui/components/ss-input.events';
+import { ListFilterUpdatedEvent } from '@/components/list-filter/list-filter.events';
+import { themed } from '@/lib/Theme';
+
+import { FactFormProp, factFormProps, FactFormProps } from './fact-form.models';
+import { FactContextChangedEvent } from './fact-form.events';
+
+import '@ss/ui/components/ss-input';
+import '@ss/ui/components/ss-select';
+import '@/components/list-filter-control/list-filter-control';
+
+const operationOptions = [
+  { value: FactOperation.ENTITY_COUNT, label: translate('factOperation.entityCount') },
+  { value: FactOperation.UNIQUE_TAG_COUNT, label: translate('factOperation.uniqueTagCount') },
+  { value: FactOperation.MEDAL_COUNT, label: translate('factOperation.medalCount') },
+  { value: FactOperation.ANALYSIS_CLASSIFICATION, label: translate('factOperation.analysisClassification') },
+  { value: FactOperation.PROPERTY_SUM, label: translate('factOperation.propertySum') },
+];
+
+@themed()
+@customElement('fact-form')
+export class FactForm extends MobxLitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .row {
+      display: flex;
+      gap: 0.75rem;
+      align-items: flex-end;
+      margin-bottom: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      gap: 0.25rem;
+      min-width: 8rem;
+    }
+
+    .field label {
+      font-size: 0.8125rem;
+      font-weight: bold;
+    }
+
+    .context-fields {
+      border-top: 1px solid var(--color-border, #eee);
+      padding-top: 0.75rem;
+      margin-top: 0.25rem;
+    }
+
+    .section-label {
+      font-size: 0.8125rem;
+      font-weight: bold;
+      margin-bottom: 0.5rem;
+      opacity: 0.7;
+    }
+  `;
+
+  @property({ type: Object })
+  [FactFormProp.CONTEXT]: FactFormProps[FactFormProp.CONTEXT] =
+    factFormProps[FactFormProp.CONTEXT].default;
+
+  @state() private localContext: FactContext = factFormProps[FactFormProp.CONTEXT].default;
+
+  updated(changedProperties: Map<string, unknown>): void {
+    if (changedProperties.has(FactFormProp.CONTEXT) && this[FactFormProp.CONTEXT]) {
+      this.localContext = this[FactFormProp.CONTEXT];
+    }
+  }
+
+  private emit(context: FactContext): void {
+    this.localContext = context;
+    this.dispatchEvent(new FactContextChangedEvent({ context }));
+  }
+
+  private getIntPropertyOptions(): { value: string; label: string }[] {
+    const seen = new Set<number>();
+    const options: { value: string; label: string }[] = [];
+    for (const config of appState.entityConfigs) {
+      for (const property of config.properties) {
+        if (property.dataType === DataType.INT && !seen.has(property.id)) {
+          seen.add(property.id);
+          options.push({ value: String(property.id), label: property.name });
+        }
+      }
+    }
+    return options;
+  }
+
+  private renderFilterSection(
+    context: EntityCountFactContext | UniqueTagCountFactContext | AnalysisClassificationFactContext | PropertySumFactContext,
+  ): TemplateResult {
+    return html`
+      <div class="context-fields">
+        <div class="section-label">${translate('filterSettings')}</div>
+        <list-filter-control
+          showAll
+          .listFilter=${context.filter}
+          @list-filter-updated=${(e: ListFilterUpdatedEvent): void => {
+            this.emit({ ...context, filter: e.detail });
+          }}
+        ></list-filter-control>
+      </div>
+    `;
+  }
+
+  private renderMedalCountFields(context: MedalCountFactContext): TemplateResult {
+    return html`
+      <div class="context-fields">
+        <div class="row">
+          <div class="field">
+            <label>${translate('medalConfigId')}</label>
+            <ss-input
+              .value=${String(context.medalConfigId)}
+              @input-changed=${(e: InputChangedEvent): void => {
+                this.emit({ ...context, medalConfigId: Number(e.detail.value) });
+              }}
+            ></ss-input>
+          </div>
+          <div class="field">
+            <label>${translate('series')}</label>
+            <ss-input
+              .value=${context.series}
+              @input-changed=${(e: InputChangedEvent): void => {
+                this.emit({ ...context, series: e.detail.value });
+              }}
+            ></ss-input>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAnalysisClassificationFields(
+    context: AnalysisClassificationFactContext,
+  ): TemplateResult {
+    return html`
+      <div class="context-fields">
+        <div class="row">
+          <div class="field">
+            <label>${translate('analysisType')}</label>
+            <ss-select
+              .options=${Object.values(AnalysisClassificationType).map(v => ({
+                value: v,
+                label: translate(`analysisType.${v}`),
+              }))}
+              .selected=${context.analysisType}
+              @select-changed=${(e: SelectChangedEvent<AnalysisClassificationType>): void => {
+                this.emit({ ...context, analysisType: e.detail.value });
+              }}
+            ></ss-select>
+          </div>
+        </div>
+      </div>
+      ${this.renderFilterSection(context)}
+    `;
+  }
+
+  private renderPropertySumFields(context: PropertySumFactContext): TemplateResult {
+    return html`
+      <div class="context-fields">
+        <div class="row">
+          <div class="field">
+            <label>${translate('propertyConfigId')}</label>
+            <ss-select
+              .options=${this.getIntPropertyOptions()}
+              .selected=${String(context.propertyConfigId)}
+              @select-changed=${(e: SelectChangedEvent<string>): void => {
+                this.emit({ ...context, propertyConfigId: Number(e.detail.value) });
+              }}
+            ></ss-select>
+          </div>
+        </div>
+      </div>
+      ${this.renderFilterSection(context)}
+    `;
+  }
+
+  render(): TemplateResult {
+    const ctx = this.localContext;
+    const { operation } = ctx;
+
+    return html`
+      <div class="row">
+        <div class="field">
+          <label>${translate('operation')}</label>
+          <ss-select
+            .options=${operationOptions}
+            .selected=${operation}
+            @select-changed=${(e: SelectChangedEvent<FactOperation>): void => {
+              const op = e.detail.value;
+              let newContext: FactContext;
+              if (op === FactOperation.MEDAL_COUNT) {
+                newContext = { operation: op, medalConfigId: 0, series: '' };
+              } else if (op === FactOperation.ANALYSIS_CLASSIFICATION) {
+                newContext = {
+                  operation: op,
+                  filter: { ...defaultListFilter },
+                  analysisType: AnalysisClassificationType.MORNING_FASTING,
+                };
+              } else if (op === FactOperation.PROPERTY_SUM) {
+                newContext = { operation: op, filter: { ...defaultListFilter }, propertyConfigId: 0 };
+              } else {
+                newContext = { operation: op, filter: { ...defaultListFilter } };
+              }
+              this.emit(newContext);
+            }}
+          ></ss-select>
+        </div>
+      </div>
+
+      ${operation === FactOperation.ENTITY_COUNT || operation === FactOperation.UNIQUE_TAG_COUNT
+        ? this.renderFilterSection(
+            ctx as EntityCountFactContext | UniqueTagCountFactContext,
+          )
+        : nothing}
+      ${operation === FactOperation.MEDAL_COUNT
+        ? this.renderMedalCountFields(ctx as MedalCountFactContext)
+        : nothing}
+      ${operation === FactOperation.ANALYSIS_CLASSIFICATION
+        ? this.renderAnalysisClassificationFields(ctx as AnalysisClassificationFactContext)
+        : nothing}
+      ${operation === FactOperation.PROPERTY_SUM
+        ? this.renderPropertySumFields(ctx as PropertySumFactContext)
+        : nothing}
+    `;
+  }
+}

--- a/src/components/fact-list/fact-list.ts
+++ b/src/components/fact-list/fact-list.ts
@@ -1,0 +1,211 @@
+import { html, css, TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+
+import { Fact, FactResult } from 'api-spec/models/Fact';
+
+import { translate } from '@/lib/Localization';
+import { appState } from '@/state';
+import { storage } from '@/lib/Storage';
+import { addToast } from '@/lib/Util';
+import { NotificationType } from '@ss/ui/components/notification-provider.models';
+import { CollapsableToggledEvent } from '@ss/ui/components/ss-collapsable.events';
+import { ConfirmationAcceptedEvent } from '@ss/ui/components/confirmation-modal.events';
+import { FactSavedEvent } from '@/components/fact-config-form/fact-config-form.events';
+
+import '@ss/ui/components/ss-collapsable';
+import '@ss/ui/components/ss-button';
+import '@ss/ui/components/confirmation-modal';
+import '@/components/fact-config-form/fact-config-form';
+
+@customElement('fact-list')
+export class FactList extends MobxLitElement {
+  private appState = appState;
+
+  @state() private facts: Fact[] = [];
+  @state() private results: FactResult[] = [];
+  @state() private confirmDeleteFactId: number | null = null;
+  @state() private editingFactId: number | null = null;
+
+  static styles = css`
+    .saved-facts {
+      margin-top: 2rem;
+    }
+
+    ss-collapsable {
+      display: block;
+      margin-bottom: 1rem;
+    }
+
+    .saved-facts-heading {
+      font-size: 1.1rem;
+      font-weight: bold;
+      margin-bottom: 0.75rem;
+    }
+
+    .no-saved-facts {
+      font-style: italic;
+      padding: 0.5rem 0;
+    }
+
+    .fact-actions {
+      display: flex;
+      gap: 0.5rem;
+      padding: 0.75rem 0;
+    }
+
+    .fact-stats {
+      display: flex;
+      gap: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .stat {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .stat-label {
+      font-size: 0.8125rem;
+      opacity: 0.7;
+    }
+
+    .stat-value {
+      font-size: 1.25rem;
+      font-weight: bold;
+    }
+  `;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    void this.loadFacts();
+  }
+
+  refresh(): void {
+    void this.loadFacts();
+  }
+
+  private async loadFacts(): Promise<void> {
+    const data = await storage.getFacts();
+    this.facts = data.facts;
+    this.results = data.results;
+  }
+
+  private getResult(factId: number): FactResult | undefined {
+    return this.results.find(r => r.factId === factId);
+  }
+
+  private handleDeleteRequested(id: number): void {
+    this.confirmDeleteFactId = id;
+  }
+
+  private async handleDeleteConfirmed(): Promise<void> {
+    const id = this.confirmDeleteFactId;
+    this.confirmDeleteFactId = null;
+
+    if (id === null) {
+      return;
+    }
+
+    const success = await storage.deleteFact?.(id);
+
+    if (!success) {
+      addToast(translate('failedToDeleteFact'), NotificationType.ERROR);
+      return;
+    }
+
+    this.facts = this.facts.filter(f => f.id !== id);
+    addToast(translate('factDeleted'), NotificationType.SUCCESS);
+  }
+
+  private handleEdit(id: number): void {
+    this.editingFactId = id;
+  }
+
+  private handleCancelEdit(): void {
+    this.editingFactId = null;
+  }
+
+  private handleFactSaved(e: FactSavedEvent): void {
+    e.stopPropagation();
+    this.editingFactId = null;
+    void this.loadFacts();
+  }
+
+  private isPanelOpen(id: number): boolean {
+    return this.appState.collapsablePanelState[`fact-${id}`] || false;
+  }
+
+  private renderFactView(fact: Fact): TemplateResult {
+    const result = this.getResult(fact.id);
+    return html`
+      <div class="fact-stats">
+        <div class="stat">
+          <span class="stat-label">${translate('factValue')}</span>
+          <span class="stat-value">${result?.value ?? 0}</span>
+        </div>
+      </div>
+      <div class="fact-actions">
+        <ss-button
+          @click=${(): void => this.handleEdit(fact.id)}
+        >${translate('editFact')}</ss-button>
+        <ss-button
+          negative
+          @click=${(): void => this.handleDeleteRequested(fact.id)}
+        >${translate('deleteFact')}</ss-button>
+      </div>
+    `;
+  }
+
+  private renderFactEdit(fact: Fact): TemplateResult {
+    return html`
+      <fact-config-form
+        .fact=${fact}
+        @fact-saved=${(e: FactSavedEvent): void => this.handleFactSaved(e)}
+      ></fact-config-form>
+      <div class="fact-actions">
+        <ss-button @click=${(): void => this.handleCancelEdit()}
+          >${translate('cancelEdit')}</ss-button>
+      </div>
+    `;
+  }
+
+  render(): TemplateResult {
+    return html`
+      <confirmation-modal
+        message=${translate('confirmDeleteFact')}
+        ?open=${this.confirmDeleteFactId !== null}
+        @confirmation-accepted=${(_e: ConfirmationAcceptedEvent): Promise<void> =>
+          this.handleDeleteConfirmed()}
+        @confirmation-declined=${(): void => {
+          this.confirmDeleteFactId = null;
+        }}
+      ></confirmation-modal>
+      <div class="saved-facts">
+        <div class="saved-facts-heading">${translate('savedFacts')}</div>
+        ${this.facts.length === 0
+          ? html`<div class="no-saved-facts">${translate('noSavedFacts')}</div>`
+          : repeat(
+              this.facts,
+              fact => fact.id,
+              fact => html`
+                <ss-collapsable
+                  title=${fact.name}
+                  panelId=${'fact-' + fact.id}
+                  ?open=${this.isPanelOpen(fact.id)}
+                  @collapsable-toggled=${(e: CollapsableToggledEvent): void => {
+                    this.dispatchEvent(new CollapsableToggledEvent(e.detail));
+                  }}
+                >
+                  ${this.editingFactId === fact.id
+                    ? this.renderFactEdit(fact)
+                    : this.renderFactView(fact)}
+                </ss-collapsable>
+              `,
+            )}
+      </div>
+    `;
+  }
+}

--- a/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
+++ b/src/components/medal-config-form/fact-request-editor/fact-request-editor.ts
@@ -1,23 +1,10 @@
-import { html, css, nothing, TemplateResult } from 'lit';
+import { html, css, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 
 import { FactRequest } from 'api-spec/models/Fact';
-import {
-  FactOperation,
-  EntityCountFactContext,
-  UniqueTagCountFactContext,
-  MedalCountFactContext,
-  AnalysisClassificationFactContext,
-  AnalysisClassificationType,
-  PropertySumFactContext,
-} from 'api-spec/models/Fact';
-import { DataType } from 'api-spec/models/Entity';
-import { defaultListFilter } from 'api-spec/models/List';
 
 import { translate } from '@/lib/Localization';
-import { appState } from '@/state';
-import { SelectChangedEvent } from '@ss/ui/components/ss-select.events';
 import { InputChangedEvent } from '@ss/ui/components/ss-input.events';
 import { themed } from '@/lib/Theme';
 
@@ -27,20 +14,11 @@ import {
   FactRequestEditorProps,
 } from './fact-request-editor.models';
 import { FactRequestChangedEvent, FactRequestRemovedEvent } from './fact-request-editor.events';
-import { ListFilterUpdatedEvent } from '@/components/list-filter/list-filter.events';
+import { FactContextChangedEvent } from '@/components/fact-form/fact-form.events';
 
 import '@ss/ui/components/ss-input';
-import '@ss/ui/components/ss-select';
 import '@ss/ui/components/ss-button';
-import '@/components/list-filter-control/list-filter-control';
-
-const operationOptions = [
-  { value: FactOperation.ENTITY_COUNT, label: translate('factOperation.entityCount') },
-  { value: FactOperation.UNIQUE_TAG_COUNT, label: translate('factOperation.uniqueTagCount') },
-  { value: FactOperation.MEDAL_COUNT, label: translate('factOperation.medalCount') },
-  { value: FactOperation.ANALYSIS_CLASSIFICATION, label: translate('factOperation.analysisClassification') },
-  { value: FactOperation.PROPERTY_SUM, label: translate('factOperation.propertySum') },
-];
+import '@/components/fact-form/fact-form';
 
 @themed()
 @customElement('fact-request-editor')
@@ -74,20 +52,6 @@ export class FactRequestEditor extends MobxLitElement {
       font-size: 0.8125rem;
       font-weight: bold;
     }
-
-    .context-fields {
-      border-top: 1px solid var(--color-border, #eee);
-      padding-top: 0.75rem;
-      margin-top: 0.25rem;
-    }
-
-    .section-label {
-      font-size: 0.8125rem;
-      font-weight: bold;
-      margin-bottom: 0.5rem;
-      opacity: 0.7;
-    }
-
   `;
 
   @property({ type: Object })
@@ -107,133 +71,9 @@ export class FactRequestEditor extends MobxLitElement {
     );
   }
 
-  private getIntPropertyOptions(
-    includeTypes: number[],
-  ): { value: string; label: string }[] {
-    const configs =
-      includeTypes.length > 0
-        ? appState.entityConfigs.filter(c => includeTypes.includes(c.id))
-        : appState.entityConfigs;
-    const seen = new Set<number>();
-    const options: { value: string; label: string }[] = [];
-    for (const config of configs) {
-      for (const property of config.properties) {
-        if (property.dataType === DataType.INT && !seen.has(property.id)) {
-          seen.add(property.id);
-          options.push({ value: String(property.id), label: property.name });
-        }
-      }
-    }
-    return options;
-  }
-
-  private renderFilterButton(
-    context: EntityCountFactContext | UniqueTagCountFactContext | AnalysisClassificationFactContext | PropertySumFactContext,
-    fr: FactRequest,
-  ): TemplateResult {
-    return html`
-      <div class="context-fields">
-        <div class="section-label">${translate('filterSettings')}</div>
-        <list-filter-control
-          showAll
-          .listFilter=${context.filter}
-          @list-filter-updated=${(e: ListFilterUpdatedEvent): void => {
-            this.emit({ ...fr, context: { ...context, filter: e.detail } });
-          }}
-        ></list-filter-control>
-      </div>
-    `;
-  }
-
-  private renderAnalysisClassificationFields(
-    context: AnalysisClassificationFactContext,
-    fr: FactRequest,
-  ): TemplateResult {
-    return html`
-      <div class="context-fields">
-        <div class="row">
-          <div class="field">
-            <label>${translate('analysisType')}</label>
-            <ss-select
-              .options=${Object.values(AnalysisClassificationType).map(v => ({
-                value: v,
-                label: translate(`analysisType.${v}`),
-              }))}
-              .selected=${context.analysisType}
-              @select-changed=${(e: SelectChangedEvent<string>): void => {
-                this.emit({
-                  ...fr,
-                  context: { ...context, analysisType: e.detail.value as AnalysisClassificationType },
-                });
-              }}
-            ></ss-select>
-          </div>
-        </div>
-      </div>
-      ${this.renderFilterButton(context, fr)}
-    `;
-  }
-
-  private renderPropertySumFields(
-    context: PropertySumFactContext,
-    fr: FactRequest,
-  ): TemplateResult {
-    return html`
-      <div class="context-fields">
-        <div class="row">
-          <div class="field">
-            <label>${translate('propertyConfigId')}</label>
-            <ss-select
-              .options=${this.getIntPropertyOptions(context.filter.includeTypes ?? [])}
-              .selected=${String(context.propertyConfigId)}
-              @select-changed=${(e: SelectChangedEvent<string>): void => {
-                this.emit({
-                  ...fr,
-                  context: {
-                    ...context,
-                    propertyConfigId: Number(e.detail.value),
-                  },
-                });
-              }}
-            ></ss-select>
-          </div>
-        </div>
-      </div>
-      ${this.renderFilterButton(context, fr)}
-    `;
-  }
-
-  private renderMedalCountFields(context: MedalCountFactContext, fr: FactRequest): TemplateResult {
-    return html`
-      <div class="context-fields">
-        <div class="row">
-          <div class="field">
-            <label>${translate('medalConfigId')}</label>
-            <ss-input
-              .value=${String(context.medalConfigId)}
-              @input-changed=${(e: InputChangedEvent): void => {
-                this.emit({ ...fr, context: { ...context, medalConfigId: Number(e.detail.value) } });
-              }}
-            ></ss-input>
-          </div>
-          <div class="field">
-            <label>${translate('series')}</label>
-            <ss-input
-              .value=${context.series}
-              @input-changed=${(e: InputChangedEvent): void => {
-                this.emit({ ...fr, context: { ...context, series: e.detail.value } });
-              }}
-            ></ss-input>
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
   render(): TemplateResult {
     const fr = this[FactRequestEditorProp.FACT_REQUEST];
     const idx = this[FactRequestEditorProp.INDEX];
-    const { operation } = fr.context;
 
     return html`
       <div class="row">
@@ -246,27 +86,6 @@ export class FactRequestEditor extends MobxLitElement {
             }}
           ></ss-input>
         </div>
-        <div class="field">
-          <label>${translate('operation')}</label>
-          <ss-select
-            .options=${operationOptions}
-            .selected=${operation}
-            @select-changed=${(e: SelectChangedEvent<FactOperation>): void => {
-              const op = e.detail.value;
-              let newContext;
-              if (op === FactOperation.MEDAL_COUNT) {
-                newContext = { operation: op, medalConfigId: 0, series: '' };
-              } else if (op === FactOperation.ANALYSIS_CLASSIFICATION) {
-                newContext = { operation: op, filter: { ...defaultListFilter }, analysisType: AnalysisClassificationType.MORNING_FASTING };
-              } else if (op === FactOperation.PROPERTY_SUM) {
-                newContext = { operation: op, filter: { ...defaultListFilter }, propertyConfigId: 0 };
-              } else {
-                newContext = { operation: op, filter: { ...defaultListFilter } };
-              }
-              this.emit({ ...fr, context: newContext });
-            }}
-          ></ss-select>
-        </div>
         <ss-button
           negative
           @click=${(): void => {
@@ -275,24 +94,12 @@ export class FactRequestEditor extends MobxLitElement {
         >${translate('remove')}</ss-button>
       </div>
 
-      ${operation === FactOperation.ENTITY_COUNT || operation === FactOperation.UNIQUE_TAG_COUNT
-        ? this.renderFilterButton(
-            fr.context as EntityCountFactContext | UniqueTagCountFactContext,
-            fr,
-          )
-        : nothing}
-      ${operation === FactOperation.MEDAL_COUNT
-        ? this.renderMedalCountFields(fr.context as MedalCountFactContext, fr)
-        : nothing}
-      ${operation === FactOperation.ANALYSIS_CLASSIFICATION
-        ? this.renderAnalysisClassificationFields(
-            fr.context as AnalysisClassificationFactContext,
-            fr,
-          )
-        : nothing}
-      ${operation === FactOperation.PROPERTY_SUM
-        ? this.renderPropertySumFields(fr.context as PropertySumFactContext, fr)
-        : nothing}
+      <fact-form
+        .context=${fr.context}
+        @fact-context-changed=${(e: FactContextChangedEvent): void => {
+          this.emit({ ...fr, context: e.detail.context });
+        }}
+      ></fact-form>
     `;
   }
 }

--- a/src/components/user-dashboard/user-dashboard.ts
+++ b/src/components/user-dashboard/user-dashboard.ts
@@ -10,11 +10,12 @@ import {
   ChartResponse,
   ChartVersion,
 } from 'api-spec/models/Statistic';
-import { FactContext, Streak, StreakResult } from 'api-spec/models/Fact';
+import { Fact, FactContext, FactResult, Streak, StreakResult } from 'api-spec/models/Fact';
 
 import '@/components/chart-js/chart-js';
 import '@/components/dashboard-cards/dashboard-cards';
 import '@/components/streak-card/streak-card';
+import '@/components/fact-card/fact-card';
 
 import { appState } from '@/state';
 import { translate } from '@/lib/Localization';
@@ -32,6 +33,8 @@ export class UserDashboard extends MobxLitElement {
   @state() private loadingChartIds: Set<number> = new Set();
   @state() private streaks: Streak[] = [];
   @state() private streakResults: StreakResult[] = [];
+  @state() private facts: Fact[] = [];
+  @state() private factResults: FactResult[] = [];
 
   static styles = css`
     .user-dashboard {
@@ -49,6 +52,12 @@ export class UserDashboard extends MobxLitElement {
     }
 
     .streak-cards {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+
+    .fact-cards {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 1rem;
@@ -101,6 +110,7 @@ export class UserDashboard extends MobxLitElement {
       },
       { label: translate('charts'), icon: IconName.CHARTS, url: '/chart' },
       { label: translate('streaks'), icon: IconName.LAYERS, url: '/streaks' },
+      { label: translate('facts'), icon: IconName.CHARTS, url: '/facts' },
       { label: translate('admin'), icon: IconName.ADMIN, url: '/admin' },
     ];
   }
@@ -122,6 +132,7 @@ export class UserDashboard extends MobxLitElement {
     super.connectedCallback();
     this.loadCharts();
     this.loadStreaks();
+    this.loadFacts();
   }
 
   private async loadStreaks(): Promise<void> {
@@ -132,6 +143,16 @@ export class UserDashboard extends MobxLitElement {
 
   private getStreakResult(streakId: number): StreakResult | undefined {
     return this.streakResults.find(r => r.streakId === streakId);
+  }
+
+  private async loadFacts(): Promise<void> {
+    const data = await storage.getFacts();
+    this.facts = data.facts;
+    this.factResults = data.results;
+  }
+
+  private getFactResult(factId: number): FactResult | undefined {
+    return this.factResults.find(r => r.factId === factId);
   }
 
   private async loadCharts(): Promise<void> {
@@ -196,6 +217,22 @@ export class UserDashboard extends MobxLitElement {
                       .streak=${streak}
                       .result=${this.getStreakResult(streak.id) ?? null}
                     ></streak-card>
+                  `,
+                )}
+              </div>
+            `
+          : nothing}
+        ${this.facts.length > 0
+          ? html`
+              <div class="fact-cards">
+                ${repeat(
+                  this.facts,
+                  fact => fact.id,
+                  fact => html`
+                    <fact-card
+                      .fact=${fact}
+                      .result=${this.getFactResult(fact.id) ?? null}
+                    ></fact-card>
                   `,
                 )}
               </div>

--- a/src/lib/NetworkStorage.ts
+++ b/src/lib/NetworkStorage.ts
@@ -43,7 +43,7 @@ import { Medal, MedalConfig } from 'api-spec/models/Medal';
 import { Workspace } from 'api-spec/models/Workspace';
 import { ThemeName } from '@/models/Page';
 import { Chart, ChartRequest, ChartResponse } from 'api-spec/models/Statistic';
-import { Streak, StreakContext, StreakResult } from 'api-spec/models/Fact';
+import { Fact, FactContext, FactResult, Streak, StreakContext, StreakResult } from 'api-spec/models/Fact';
 
 export class NetworkStorage implements StorageSchema {
   isActive = true;
@@ -1083,6 +1083,56 @@ export class NetworkStorage implements StorageSchema {
 
   async deleteStreak(id: number): Promise<boolean> {
     const result = await api.delete<null>(`streakRequest/${id}`);
+
+    if (result && result.isOk) {
+      return true;
+    }
+
+    return false;
+  }
+
+  async getFacts(): Promise<{ facts: Fact[]; results: FactResult[] }> {
+    const result = await api.get<{ facts: Fact[]; results: FactResult[] }>('factRequest');
+
+    if (result && result.isOk) {
+      return result.response;
+    }
+
+    return { facts: [], results: [] };
+  }
+
+  async createFact(name: string, context: FactContext): Promise<StorageResult<Fact>> {
+    const result = await api.post<{ name: string; context: FactContext }, { fact: Fact }>(
+      'factRequest',
+      { name, context },
+    );
+
+    if (result && result.isOk) {
+      return { isOk: true, value: result.response.fact };
+    }
+
+    return { isOk: false, error: new Error('Failed to create fact') };
+  }
+
+  async updateFact(
+    id: number,
+    name: string | undefined,
+    context: FactContext | undefined,
+  ): Promise<StorageResult<Fact>> {
+    const result = await api.put<
+      { name?: string; context?: FactContext },
+      { fact: Fact }
+    >(`factRequest/${id}`, { name, context });
+
+    if (result && result.isOk) {
+      return { isOk: true, value: result.response.fact };
+    }
+
+    return { isOk: false, error: new Error('Failed to update fact') };
+  }
+
+  async deleteFact(id: number): Promise<boolean> {
+    const result = await api.delete<null>(`factRequest/${id}`);
 
     if (result && result.isOk) {
       return true;

--- a/src/lib/OfflineCacheStorage.ts
+++ b/src/lib/OfflineCacheStorage.ts
@@ -40,7 +40,7 @@ import { Medal, MedalConfig } from 'api-spec/models/Medal';
 import { Workspace } from 'api-spec/models/Workspace';
 import { ThemeName } from '@/models/Page';
 import { Chart, ChartRequest, ChartResponse } from 'api-spec/models/Statistic';
-import { Streak, StreakContext, StreakResult } from 'api-spec/models/Fact';
+import { Fact, FactContext, FactResult, Streak, StreakContext, StreakResult } from 'api-spec/models/Fact';
 
 import { SQLiteStorage, serializePropertyValue } from './SQLiteStorage';
 import { networkStorage } from './NetworkStorage';
@@ -1335,6 +1335,26 @@ export class OfflineCacheStorage implements StorageSchema {
 
   async deleteStreak(id: number): Promise<boolean> {
     return networkStorage.deleteStreak(id);
+  }
+
+  async getFacts(): Promise<{ facts: Fact[]; results: FactResult[] }> {
+    return networkStorage.getFacts();
+  }
+
+  async createFact(name: string, context: FactContext): Promise<StorageResult<Fact>> {
+    return networkStorage.createFact(name, context);
+  }
+
+  async updateFact(
+    id: number,
+    name: string | undefined,
+    context: FactContext | undefined,
+  ): Promise<StorageResult<Fact>> {
+    return networkStorage.updateFact(id, name, context);
+  }
+
+  async deleteFact(id: number): Promise<boolean> {
+    return networkStorage.deleteFact(id);
   }
 }
 

--- a/src/lib/Storage.ts
+++ b/src/lib/Storage.ts
@@ -58,7 +58,7 @@ import {
 import { Medal, MedalConfig } from 'api-spec/models/Medal';
 import { Workspace } from 'api-spec/models/Workspace';
 import { Chart, ChartRequest, ChartResponse } from 'api-spec/models/Statistic';
-import { Streak, StreakContext, StreakResult } from 'api-spec/models/Fact';
+import { Fact, FactContext, FactResult, Streak, StreakContext, StreakResult } from 'api-spec/models/Fact';
 
 export interface SavedListFilter {
   filter: ListFilter;
@@ -964,6 +964,33 @@ export class Storage implements StorageSchema {
 
   @delegateSource()
   async deleteStreak(_id: number): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  @delegateSource()
+  async getFacts(): Promise<{ facts: Fact[]; results: FactResult[] }> {
+    return Promise.resolve({ facts: [], results: [] });
+  }
+
+  @delegateSource()
+  async createFact(
+    _name: string,
+    _context: FactContext,
+  ): Promise<StorageResult<Fact>> {
+    return Promise.resolve({ isOk: false, error: new Error('Not implemented') });
+  }
+
+  @delegateSource()
+  async updateFact(
+    _id: number,
+    _name: string | undefined,
+    _context: FactContext | undefined,
+  ): Promise<StorageResult<Fact>> {
+    return Promise.resolve({ isOk: false, error: new Error('Not implemented') });
+  }
+
+  @delegateSource()
+  async deleteFact(_id: number): Promise<boolean> {
     return Promise.resolve(false);
   }
 

--- a/src/lib/data/localization/en.json
+++ b/src/lib/data/localization/en.json
@@ -561,5 +561,17 @@
   "currentStreak": "Current Streak",
   "longestStreak": "Longest Streak",
   "current": "Current",
-  "pb": "PB"
+  "pb": "PB",
+  "facts": "Facts",
+  "savedFacts": "Saved Facts",
+  "noSavedFacts": "No saved facts.",
+  "editFact": "Edit Fact",
+  "deleteFact": "Delete Fact",
+  "confirmDeleteFact": "Are you sure you want to delete this fact? This action cannot be undone.",
+  "factDeleted": "Fact deleted successfully.",
+  "failedToDeleteFact": "Failed to delete fact.",
+  "factSaved": "Fact saved successfully.",
+  "failedToSaveFact": "Failed to save fact.",
+  "factNameRequired": "Fact name is required.",
+  "factValue": "Value"
 }

--- a/src/models/Storage.ts
+++ b/src/models/Storage.ts
@@ -2,7 +2,7 @@ import { Setting, Settings } from 'api-spec/models/Setting';
 import { Medal, MedalConfig } from 'api-spec/models/Medal';
 import { Workspace } from 'api-spec/models/Workspace';
 import { Chart, ChartRequest, ChartResponse } from 'api-spec/models/Statistic';
-import { Streak, StreakContext, StreakResult } from 'api-spec/models/Fact';
+import { Fact, FactContext, FactResult, Streak, StreakContext, StreakResult } from 'api-spec/models/Fact';
 import { ListConfig, ListSort, ListFilter } from 'api-spec/models/List';
 import {
   EntityCalculatedPropertyConfig,
@@ -233,4 +233,8 @@ export interface StorageSchema {
   createStreak?(name: string, context: StreakContext): Promise<StorageResult<Streak>>;
   updateStreak?(id: number, name: string | undefined, context: StreakContext | undefined): Promise<StorageResult<Streak>>;
   deleteStreak?(id: number): Promise<boolean>;
+  getFacts?(): Promise<{ facts: Fact[]; results: FactResult[] }>;
+  createFact?(name: string, context: FactContext): Promise<StorageResult<Fact>>;
+  updateFact?(id: number, name: string | undefined, context: FactContext | undefined): Promise<StorageResult<Fact>>;
+  deleteFact?(id: number): Promise<boolean>;
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -117,4 +117,9 @@ export const routes: Route[] = [
     component: 'streaks-view',
     action: async () => await import('@/views/streaks-view/streaks-view'),
   },
+  {
+    path: '/facts',
+    component: 'facts-view',
+    action: async () => await import('@/views/facts-view/facts-view'),
+  },
 ];

--- a/src/views/facts-view/facts-view.ts
+++ b/src/views/facts-view/facts-view.ts
@@ -1,0 +1,55 @@
+import { html, css, TemplateResult } from 'lit';
+import { customElement, query } from 'lit/decorators.js';
+
+import { ViewElement } from '@/lib/ViewElement';
+import { themed } from '@/lib/Theme';
+import { appState } from '@/state';
+import { FactSavedEvent } from '@/components/fact-config-form/fact-config-form.events';
+import { FactList } from '@/components/fact-list/fact-list';
+
+import '@/components/user-header/user-header';
+import '@/components/login-form/login-form';
+import '@/components/fact-config-form/fact-config-form';
+import '@/components/fact-list/fact-list';
+
+@customElement('facts-view')
+@themed()
+export class FactsView extends ViewElement {
+  private appState = appState;
+
+  @query('fact-list') private factList: FactList | undefined;
+
+  static styles = css`
+    .view-content {
+      margin-top: 1rem;
+      padding: 0 1rem;
+    }
+
+    .box {
+      padding: 1rem;
+    }
+  `;
+
+  render(): TemplateResult {
+    if (!this.appState.authToken) {
+      return html`
+        <user-header></user-header>
+        <div class="view-content"><login-form></login-form></div>
+      `;
+    }
+
+    return html`
+      <user-header></user-header>
+      <div class="view-content">
+        <div class="box">
+          <fact-config-form
+            @fact-saved=${(_e: FactSavedEvent): void => {
+              this.factList?.refresh();
+            }}
+          ></fact-config-form>
+        </div>
+        <fact-list></fact-list>
+      </div>
+    `;
+  }
+}


### PR DESCRIPTION
Implements the savable facts feature as described in issue #203, following the existing streak pattern.

## Changes

- Update api-spec to 1.118.0 (introduces Fact and FactResult types)
- Add full storage layer: getFacts/createFact/updateFact/deleteFact across StorageSchema, NetworkStorage, Storage.ts, OfflineCacheStorage
- Create fact-form: shared reusable FactContext editor (replaces inline editing in fact-request-editor)
- Create fact-config-form, fact-card, fact-list components
- Create facts-view at /facts route
- Add fact cards and /facts link to user dashboard
- Add translations for all fact UI strings

Closes #203

Generated with [Claude Code](https://claude.ai/code)