### PR TITLE
Extract shared option-list-builder component

### DIFF
--- a/src/components/option-list-builder/option-list-builder.events.ts
+++ b/src/components/option-list-builder/option-list-builder.events.ts
@@ -1,0 +1,15 @@
+export const optionListUpdatedEventName = 'option-list-updated';
+
+export interface OptionListUpdatedPayload {
+  selected: string[];
+}
+
+export class OptionListUpdatedEvent extends CustomEvent<OptionListUpdatedPayload> {
+  constructor(detail: OptionListUpdatedPayload) {
+    super(optionListUpdatedEventName, {
+      detail,
+      bubbles: true,
+      composed: true,
+    });
+  }
+}

--- a/src/components/option-list-builder/option-list-builder.models.ts
+++ b/src/components/option-list-builder/option-list-builder.models.ts
@@ -1,0 +1,37 @@
+import { ControlType } from '@/models/Control';
+import { PropConfigMap, PropTypes } from '@/models/Prop';
+
+export interface OptionListBuilderItem {
+  id: string;
+  label: string;
+}
+
+export enum OptionListBuilderProp {
+  AVAILABLE = 'available',
+  SELECTED = 'selected',
+  EMPTY_MESSAGE = 'emptyMessage',
+}
+
+export interface OptionListBuilderProps extends PropTypes {
+  [OptionListBuilderProp.AVAILABLE]: OptionListBuilderItem[];
+  [OptionListBuilderProp.SELECTED]: string[];
+  [OptionListBuilderProp.EMPTY_MESSAGE]: string;
+}
+
+export const optionListBuilderProps: PropConfigMap<OptionListBuilderProps> = {
+  [OptionListBuilderProp.AVAILABLE]: {
+    default: [],
+    description: 'The options that can be added to the selected list',
+    control: { type: ControlType.HIDDEN },
+  },
+  [OptionListBuilderProp.SELECTED]: {
+    default: [],
+    description: 'The ids of the currently selected options, in order',
+    control: { type: ControlType.HIDDEN },
+  },
+  [OptionListBuilderProp.EMPTY_MESSAGE]: {
+    default: '',
+    description: 'Message shown when no options are selected',
+    control: { type: ControlType.TEXT },
+  },
+};

--- a/src/components/option-list-builder/option-list-builder.ts
+++ b/src/components/option-list-builder/option-list-builder.ts
@@ -1,0 +1,149 @@
+import { css, html, LitElement, TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+import '@ss/ui/components/sortable-list';
+import '@ss/ui/components/sortable-item';
+import '@ss/ui/components/ss-icon';
+import { SortUpdatedEvent } from '@ss/ui/components/sortable-list.events';
+
+import {
+  OptionListBuilderItem,
+  OptionListBuilderProp,
+  optionListBuilderProps,
+  OptionListBuilderProps,
+} from './option-list-builder.models';
+import { OptionListUpdatedEvent } from './option-list-builder.events';
+
+@customElement('option-list-builder')
+export class OptionListBuilder extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+    }
+
+    ul li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.25rem 0;
+    }
+
+    ul li.active {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+
+    ul li.active ss-icon {
+      display: none;
+    }
+
+    ss-icon {
+      cursor: pointer;
+    }
+
+    .empty {
+      font-style: italic;
+    }
+  `;
+
+  @property({ type: Array })
+  [OptionListBuilderProp.AVAILABLE]: OptionListBuilderProps[OptionListBuilderProp.AVAILABLE] =
+    optionListBuilderProps[OptionListBuilderProp.AVAILABLE].default;
+
+  @property({ type: Array })
+  [OptionListBuilderProp.SELECTED]: OptionListBuilderProps[OptionListBuilderProp.SELECTED] =
+    optionListBuilderProps[OptionListBuilderProp.SELECTED].default;
+
+  @property({ type: String })
+  [OptionListBuilderProp.EMPTY_MESSAGE]: OptionListBuilderProps[OptionListBuilderProp.EMPTY_MESSAGE] =
+    optionListBuilderProps[OptionListBuilderProp.EMPTY_MESSAGE].default;
+
+  private get selectedItems(): OptionListBuilderItem[] {
+    return this[OptionListBuilderProp.SELECTED]
+      .map(id =>
+        this[OptionListBuilderProp.AVAILABLE].find(item => item.id === id),
+      )
+      .filter((item): item is OptionListBuilderItem => item !== undefined);
+  }
+
+  private addOption(id: string): void {
+    this.dispatchEvent(
+      new OptionListUpdatedEvent({
+        selected: [...this[OptionListBuilderProp.SELECTED], id],
+      }),
+    );
+  }
+
+  private removeOption(id: string): void {
+    this.dispatchEvent(
+      new OptionListUpdatedEvent({
+        selected: this[OptionListBuilderProp.SELECTED].filter(
+          selectedId => selectedId !== id,
+        ),
+      }),
+    );
+  }
+
+  private handleSortUpdated(e: SortUpdatedEvent): void {
+    this.dispatchEvent(
+      new OptionListUpdatedEvent({
+        selected: e.detail.sortedIds,
+      }),
+    );
+  }
+
+  render(): TemplateResult {
+    return html`
+      <slot name="available-heading"></slot>
+      <ul class="available">
+        ${repeat(
+          this[OptionListBuilderProp.AVAILABLE],
+          item => item.id,
+          item =>
+            html`<li
+              class=${classMap({
+                active: this[OptionListBuilderProp.SELECTED].includes(
+                  item.id,
+                ),
+              })}
+            >
+              <span>${item.label}</span>
+              <ss-icon
+                name="add"
+                size="16"
+                @click=${(): void => this.addOption(item.id)}
+              ></ss-icon>
+            </li>`,
+        )}
+      </ul>
+
+      <slot name="selected-heading"></slot>
+      ${this.selectedItems.length > 0
+        ? html`
+            <sortable-list @sort-updated=${this.handleSortUpdated}>
+              ${this.selectedItems.map(
+                item =>
+                  html`<sortable-item id=${item.id}>
+                    <span>${item.label}</span>
+                    <ss-icon
+                      name="trash"
+                      size="16"
+                      @click=${(): void => this.removeOption(item.id)}
+                    ></ss-icon>
+                  </sortable-item>`,
+              )}
+            </sortable-list>
+          `
+        : html`<p class="empty">
+            ${this[OptionListBuilderProp.EMPTY_MESSAGE]}
+          </p>`}
+    `;
+  }
+}

--- a/src/components/theme-manager/theme-manager.ts
+++ b/src/components/theme-manager/theme-manager.ts
@@ -7,45 +7,17 @@ import {
 } from './theme-manager.models';
 import { translate } from '@/lib/Localization';
 import { ThemeName } from '@/models/Page';
-import { repeat } from 'lit/directives/repeat.js';
 
-import '@ss/ui/components/sortable-list';
-import '@ss/ui/components/sortable-item';
-import '@ss/ui/components/ss-icon';
+import '@/components/option-list-builder/option-list-builder';
+import { OptionListBuilderItem } from '@/components/option-list-builder/option-list-builder.models';
+import { OptionListUpdatedEvent } from '@/components/option-list-builder/option-list-builder.events';
 import { ThemesUpdatedEvent, ThemesSavedEvent } from './theme-manager.events';
-import { classMap } from 'lit/directives/class-map.js';
-import { SortUpdatedEvent } from '@ss/ui/components/sortable-list.events';
 import { themed } from '@/lib/Theme';
 
 @themed()
 @customElement('theme-manager')
 export class ThemeManager extends LitElement {
   static styles = css`
-    ul {
-      list-style: none;
-      padding: 0;
-
-      li {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0.5;
-      }
-    }
-
-    .available-themes li.active {
-      opacity: 0.5;
-      pointer-events: none;
-
-      ss-icon {
-        display: none;
-      }
-    }
-
-    ss-icon {
-      cursor: pointer;
-    }
-
     .buttons {
       margin-top: 1rem;
     }
@@ -59,8 +31,11 @@ export class ThemeManager extends LitElement {
   initialActive: string[] = [];
 
   @state()
-  get available(): string[] {
-    return Object.values(ThemeName);
+  get available(): OptionListBuilderItem[] {
+    return Object.values(ThemeName).map(theme => ({
+      id: theme,
+      label: theme,
+    }));
   }
 
   @state()
@@ -77,34 +52,16 @@ export class ThemeManager extends LitElement {
     this.initialActive = [...this[ThemeManagerProp.ACTIVE]];
   }
 
-  addTheme(theme: string): void {
-    this.dispatchEvent(
-      new ThemesUpdatedEvent({
-        themes: [...this[ThemeManagerProp.ACTIVE], theme],
-      }),
-    );
-  }
-
-  removeTheme(theme: string): void {
-    this.dispatchEvent(
-      new ThemesUpdatedEvent({
-        themes: this[ThemeManagerProp.ACTIVE].filter(t => t !== theme),
-      }),
-    );
-  }
-
   saveThemes(): void {
     this.dispatchEvent(
       new ThemesSavedEvent({ themes: this[ThemeManagerProp.ACTIVE] }),
     );
   }
 
-  handleSortUpdated(e: SortUpdatedEvent): void {
-    const themes = e.detail.sortedIds;
-
+  private handleOptionListUpdated(e: OptionListUpdatedEvent): void {
     this.dispatchEvent(
       new ThemesUpdatedEvent({
-        themes,
+        themes: e.detail.selected,
       }),
     );
   }
@@ -112,47 +69,15 @@ export class ThemeManager extends LitElement {
   render(): TemplateResult {
     return html`
       <div>
-        <h3>${translate('availableThemes')}</h3>
-
-        <ul class="available-themes">
-          ${repeat(
-            this.available,
-            theme => theme,
-            theme =>
-              html`<li
-                class=${classMap({
-                  active: this[ThemeManagerProp.ACTIVE].includes(theme),
-                })}
-              >
-                <span>${theme}</span
-                ><ss-icon
-                  name="add"
-                  size="16"
-                  @click=${(): void => this.addTheme(theme)}
-                ></ss-icon>
-              </li>`,
-          )}
-        </ul>
-
-        <h3>${translate('activeThemes')}</h3>
-        ${this[ThemeManagerProp.ACTIVE].length > 0
-          ? html`<sortable-list
-              class="active-themes"
-              @sort-updated=${this.handleSortUpdated}
-            >
-              ${this[ThemeManagerProp.ACTIVE].map(
-                theme =>
-                  html`<sortable-item id=${theme}>
-                    <span>${theme}</span>
-                    <ss-icon
-                      name="trash"
-                      size="16"
-                      @click=${(): void => this.removeTheme(theme)}
-                    ></ss-icon>
-                  </sortable-item>`,
-              )}
-            </sortable-list>`
-          : translate('noThemesActive')}
+        <option-list-builder
+          .available=${this.available}
+          .selected=${this[ThemeManagerProp.ACTIVE]}
+          emptyMessage=${translate('noThemesActive')}
+          @option-list-updated=${this.handleOptionListUpdated}
+        >
+          <h3 slot="available-heading">${translate('availableThemes')}</h3>
+          <h3 slot="selected-heading">${translate('activeThemes')}</h3>
+        </option-list-builder>
 
         <div class="buttons">
           <ss-button

--- a/src/components/workspace-fact-manager/workspace-fact-manager.ts
+++ b/src/components/workspace-fact-manager/workspace-fact-manager.ts
@@ -1,7 +1,5 @@
 import { html, css, TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { repeat } from 'lit/directives/repeat.js';
-import { classMap } from 'lit/directives/class-map.js';
 
 import { Fact } from 'api-spec/models/Fact';
 import { translate } from '@/lib/Localization';
@@ -12,10 +10,9 @@ import { NotificationType } from '@ss/ui/components/notification-provider.models
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { themed } from '@/lib/Theme';
 
-import '@ss/ui/components/sortable-list';
-import '@ss/ui/components/sortable-item';
-import '@ss/ui/components/ss-icon';
-import { SortUpdatedEvent } from '@ss/ui/components/sortable-list.events';
+import '@/components/option-list-builder/option-list-builder';
+import { OptionListBuilderItem } from '@/components/option-list-builder/option-list-builder.models';
+import { OptionListUpdatedEvent } from '@/components/option-list-builder/option-list-builder.events';
 
 import {
   WorkspaceFactManagerProp,
@@ -35,35 +32,6 @@ export class WorkspaceFactManager extends MobxLitElement {
     a {
       display: inline-block;
       margin-bottom: 1rem;
-    }
-
-    ul {
-      list-style: none;
-      padding: 0;
-    }
-
-    ul li {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 0.25rem 0;
-    }
-
-    ul li.active {
-      opacity: 0.5;
-      pointer-events: none;
-    }
-
-    ul li.active ss-icon {
-      display: none;
-    }
-
-    ss-icon {
-      cursor: pointer;
-    }
-
-    .empty {
-      font-style: italic;
     }
 
     h3 {
@@ -92,32 +60,17 @@ export class WorkspaceFactManager extends MobxLitElement {
     }
   }
 
-  private get workspaceFacts(): Fact[] {
-    return this[WorkspaceFactManagerProp.FACTS]
-      .map(id => this.allFacts.find(f => f.id === id))
-      .filter((f): f is Fact => f !== undefined);
+  private get availableFacts(): OptionListBuilderItem[] {
+    return this.allFacts.map(fact => ({
+      id: String(fact.id),
+      label: fact.name,
+    }));
   }
 
-  private addFact(factId: number): void {
+  private handleOptionListUpdated(e: OptionListUpdatedEvent): void {
     this.dispatchEvent(
       new WorkspaceFactsChangedEvent({
-        facts: [...this[WorkspaceFactManagerProp.FACTS], factId],
-      }),
-    );
-  }
-
-  private removeFact(factId: number): void {
-    this.dispatchEvent(
-      new WorkspaceFactsChangedEvent({
-        facts: this[WorkspaceFactManagerProp.FACTS].filter(id => id !== factId),
-      }),
-    );
-  }
-
-  private handleSortUpdated(e: SortUpdatedEvent): void {
-    this.dispatchEvent(
-      new WorkspaceFactsChangedEvent({
-        facts: e.detail.sortedIds.map(Number),
+        facts: e.detail.selected.map(Number),
       }),
     );
   }
@@ -126,45 +79,15 @@ export class WorkspaceFactManager extends MobxLitElement {
     return html`
       <a href="/facts">${translate('manageFacts')}</a>
 
-      <h3>${translate('availableFacts')}</h3>
-      <ul>
-        ${repeat(
-          this.allFacts,
-          fact => fact.id,
-          fact =>
-            html`<li
-              class=${classMap({
-                active: this[WorkspaceFactManagerProp.FACTS].includes(fact.id),
-              })}
-            >
-              <span>${fact.name}</span>
-              <ss-icon
-                name="add"
-                size="16"
-                @click=${(): void => this.addFact(fact.id)}
-              ></ss-icon>
-            </li>`,
-        )}
-      </ul>
-
-      <h3>${translate('workspaceFacts')}</h3>
-      ${this.workspaceFacts.length > 0
-        ? html`
-            <sortable-list @sort-updated=${this.handleSortUpdated}>
-              ${this.workspaceFacts.map(
-                fact =>
-                  html`<sortable-item id=${String(fact.id)}>
-                    <span>${fact.name}</span>
-                    <ss-icon
-                      name="trash"
-                      size="16"
-                      @click=${(): void => this.removeFact(fact.id)}
-                    ></ss-icon>
-                  </sortable-item>`,
-              )}
-            </sortable-list>
-          `
-        : html`<p class="empty">${translate('noWorkspaceFacts')}</p>`}
+      <option-list-builder
+        .available=${this.availableFacts}
+        .selected=${this[WorkspaceFactManagerProp.FACTS].map(String)}
+        emptyMessage=${translate('noWorkspaceFacts')}
+        @option-list-updated=${this.handleOptionListUpdated}
+      >
+        <h3 slot="available-heading">${translate('availableFacts')}</h3>
+        <h3 slot="selected-heading">${translate('workspaceFacts')}</h3>
+      </option-list-builder>
     `;
   }
 }

--- a/src/components/workspace-streak-manager/workspace-streak-manager.ts
+++ b/src/components/workspace-streak-manager/workspace-streak-manager.ts
@@ -1,7 +1,5 @@
 import { html, css, TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { repeat } from 'lit/directives/repeat.js';
-import { classMap } from 'lit/directives/class-map.js';
 
 import { Streak } from 'api-spec/models/Fact';
 import { translate } from '@/lib/Localization';
@@ -12,10 +10,9 @@ import { NotificationType } from '@ss/ui/components/notification-provider.models
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { themed } from '@/lib/Theme';
 
-import '@ss/ui/components/sortable-list';
-import '@ss/ui/components/sortable-item';
-import '@ss/ui/components/ss-icon';
-import { SortUpdatedEvent } from '@ss/ui/components/sortable-list.events';
+import '@/components/option-list-builder/option-list-builder';
+import { OptionListBuilderItem } from '@/components/option-list-builder/option-list-builder.models';
+import { OptionListUpdatedEvent } from '@/components/option-list-builder/option-list-builder.events';
 
 import {
   WorkspaceStreakManagerProp,
@@ -35,35 +32,6 @@ export class WorkspaceStreakManager extends MobxLitElement {
     a {
       display: inline-block;
       margin-bottom: 1rem;
-    }
-
-    ul {
-      list-style: none;
-      padding: 0;
-    }
-
-    ul li {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 0.25rem 0;
-    }
-
-    ul li.active {
-      opacity: 0.5;
-      pointer-events: none;
-    }
-
-    ul li.active ss-icon {
-      display: none;
-    }
-
-    ss-icon {
-      cursor: pointer;
-    }
-
-    .empty {
-      font-style: italic;
     }
 
     h3 {
@@ -92,32 +60,17 @@ export class WorkspaceStreakManager extends MobxLitElement {
     }
   }
 
-  private get workspaceStreaks(): Streak[] {
-    return this[WorkspaceStreakManagerProp.STREAKS]
-      .map(id => this.allStreaks.find(s => s.id === id))
-      .filter((s): s is Streak => s !== undefined);
+  private get availableStreaks(): OptionListBuilderItem[] {
+    return this.allStreaks.map(streak => ({
+      id: String(streak.id),
+      label: streak.name,
+    }));
   }
 
-  private addStreak(streakId: number): void {
+  private handleOptionListUpdated(e: OptionListUpdatedEvent): void {
     this.dispatchEvent(
       new WorkspaceStreaksChangedEvent({
-        streaks: [...this[WorkspaceStreakManagerProp.STREAKS], streakId],
-      }),
-    );
-  }
-
-  private removeStreak(streakId: number): void {
-    this.dispatchEvent(
-      new WorkspaceStreaksChangedEvent({
-        streaks: this[WorkspaceStreakManagerProp.STREAKS].filter(id => id !== streakId),
-      }),
-    );
-  }
-
-  private handleSortUpdated(e: SortUpdatedEvent): void {
-    this.dispatchEvent(
-      new WorkspaceStreaksChangedEvent({
-        streaks: e.detail.sortedIds.map(Number),
+        streaks: e.detail.selected.map(Number),
       }),
     );
   }
@@ -126,45 +79,15 @@ export class WorkspaceStreakManager extends MobxLitElement {
     return html`
       <a href="/streaks">${translate('manageStreaks')}</a>
 
-      <h3>${translate('availableStreaks')}</h3>
-      <ul>
-        ${repeat(
-          this.allStreaks,
-          streak => streak.id,
-          streak =>
-            html`<li
-              class=${classMap({
-                active: this[WorkspaceStreakManagerProp.STREAKS].includes(streak.id),
-              })}
-            >
-              <span>${streak.name}</span>
-              <ss-icon
-                name="add"
-                size="16"
-                @click=${(): void => this.addStreak(streak.id)}
-              ></ss-icon>
-            </li>`,
-        )}
-      </ul>
-
-      <h3>${translate('workspaceStreaks')}</h3>
-      ${this.workspaceStreaks.length > 0
-        ? html`
-            <sortable-list @sort-updated=${this.handleSortUpdated}>
-              ${this.workspaceStreaks.map(
-                streak =>
-                  html`<sortable-item id=${String(streak.id)}>
-                    <span>${streak.name}</span>
-                    <ss-icon
-                      name="trash"
-                      size="16"
-                      @click=${(): void => this.removeStreak(streak.id)}
-                    ></ss-icon>
-                  </sortable-item>`,
-              )}
-            </sortable-list>
-          `
-        : html`<p class="empty">${translate('noWorkspaceStreaks')}</p>`}
+      <option-list-builder
+        .available=${this.availableStreaks}
+        .selected=${this[WorkspaceStreakManagerProp.STREAKS].map(String)}
+        emptyMessage=${translate('noWorkspaceStreaks')}
+        @option-list-updated=${this.handleOptionListUpdated}
+      >
+        <h3 slot="available-heading">${translate('availableStreaks')}</h3>
+        <h3 slot="selected-heading">${translate('workspaceStreaks')}</h3>
+      </option-list-builder>
     `;
   }
 }


### PR DESCRIPTION
Extracts the duplicated "available options → reorderable selected list" UI and behavior from `theme-manager`, `workspace-fact-manager`, and `workspace-streak-manager` into a new shared `option-list-builder` component.

- New `option-list-builder` component handles rendering the available/selected lists, add/remove/reorder logic, and shared styling.
- `theme-manager`, `workspace-fact-manager`, and `workspace-streak-manager` now delegate to it internally, translating its `option-list-updated` event into their existing public events.
- No changes to public props/events of the three wrapper components, so no changes needed in `list-config.ts` or `workspace-manager.ts`.

Closes #207.

⚠️ npm build/lint could not be run in the automated session — please verify before merging.

Generated with [Claude Code](https://claude.ai/code)