### PR TITLE
Only show workspace charts on dashboard

### DIFF
--- a/src/components/user-dashboard/user-dashboard.ts
+++ b/src/components/user-dashboard/user-dashboard.ts
@@ -214,6 +214,14 @@ export class UserDashboard extends MobxLitElement {
     return this.facts.filter(f => ids.includes(f.id));
   }
 
+  private get visibleCharts(): Chart[] {
+    const ids = this.state.activeWorkspaceChartIds;
+    if (ids === null) {
+      return this.savedCharts;
+    }
+    return this.savedCharts.filter(c => ids.includes(c.id));
+  }
+
   render(): TemplateResult {
     return html`
       <div class="user-dashboard">
@@ -258,7 +266,7 @@ export class UserDashboard extends MobxLitElement {
 
         <div class="charts">
           ${repeat(
-            this.savedCharts,
+            this.visibleCharts,
             chart => chart.id,
             chart => {
               const isLoading = this.loadingChartIds.has(chart.id);

--- a/src/state.ts
+++ b/src/state.ts
@@ -270,6 +270,19 @@ export class AppState {
     return activeWorkspace.facts ?? null;
   }
 
+  get activeWorkspaceChartIds(): number[] | null {
+    if (!this.activeWorkspaceId || !this.workspaces.length) {
+      return null;
+    }
+    const activeWorkspace = this.workspaces.find(
+      w => w.id === this.activeWorkspaceId,
+    );
+    if (!activeWorkspace) {
+      return null;
+    }
+    return activeWorkspace.charts ?? null;
+  }
+
   get workspaceEntityConfigs(): EntityConfig[] {
     if (!this.activeWorkspaceId || !this.workspaces.length) {
       return this.entityConfigs;


### PR DESCRIPTION
Closes #209.

Adds an `activeWorkspaceChartIds` computed getter to state, following the same pattern as `activeWorkspaceStreakIds`/`activeWorkspaceFactIds`, and uses it in `user-dashboard`'s `visibleCharts` getter so only charts belonging to the active workspace are shown on the dashboard. Falls back to showing all of the user's charts when there is no active workspace or it can't be found.

Generated with [Claude Code](https://claude.ai/code)