### PR TITLE
fix: include charts when saving workspaces

### DIFF
--- a/src/lib/NetworkStorage.ts
+++ b/src/lib/NetworkStorage.ts
@@ -969,7 +969,7 @@ export class NetworkStorage implements StorageSchema {
 
   async saveWorkspace(workspace: Workspace): Promise<StorageResult<Workspace>> {
     const result = await api.put<
-      { name: string; listConfigs: string[]; color: string; showEverything: boolean; theme: string; facts: number[]; streaks: number[] },
+      { name: string; listConfigs: string[]; color: string; showEverything: boolean; theme: string; facts: number[]; streaks: number[]; charts: number[] },
       Workspace
     >(`workspace/${workspace.id}`, {
       name: workspace.name,
@@ -979,6 +979,7 @@ export class NetworkStorage implements StorageSchema {
       theme: workspace.theme,
       facts: workspace.facts,
       streaks: workspace.streaks,
+      charts: workspace.charts,
     });
 
     if (result && result.isOk) {


### PR DESCRIPTION
## Summary
- `NetworkStorage.saveWorkspace` omitted `charts` from the PUT /workspace/:id request body, so chart associations made in the workspace chart manager UI were silently dropped on save.
- The backend's `WorkspaceUpdateBody` schema already supports `charts`, same as the existing `facts`/streaks` fields, so this was purely a frontend gap.
- `OfflineCacheStorage` and `SQLiteStorage` were reviewed: no changes needed there (see issue discussion for details).

Closes #211

Generated with [Claude Code](https://claude.ai/code)