### PR TITLE
fix: entity form fields losing labels when navigating between list configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ The OpenAPI spec for `gapi` lives at `docs/openapi.latest.json` (not committed â
 - Every function must include a return type
 - SVG icons should never be inserted inline. Create new component for icon if it doesn't exist in `components/svg-icon/svg`
 - Every custom event must have its own class extending `CustomEvent<TPayload>`, a named export for the event name string, and a payload type â€” never dispatch a bare `new CustomEvent(...)`. Events with no payload use `Record<string, never>` as the type. See `src/events/` for examples.
+- Prefer `async`/`await` over `.then()` callbacks whenever possible, including inside MobX `reaction()` effects and event handler methods.
 
 See [docs/code-hygeine.md](docs/code-hygeine.md) for further details on code hygeine and cleanup routines.
 

--- a/src/components/entity-form/entity-form.ts
+++ b/src/components/entity-form/entity-form.ts
@@ -207,7 +207,7 @@ export class EntityForm extends ViewElement {
 
     reaction(
       () => [appState.listConfigId, appState.listFilter],
-      () => {
+      async () => {
         if (this.entityId) {
           return;
         }
@@ -223,7 +223,8 @@ export class EntityForm extends ViewElement {
         }
 
         if (this.propertiesRef) {
-          this.updateComplete.then(() => this.propertiesRef?.reset());
+          await this.updateComplete;
+          this.propertiesRef?.reset();
         }
       },
       {
@@ -386,9 +387,12 @@ export class EntityForm extends ViewElement {
     this.confirmModalShown = true;
   }
 
-  private handleTypeChanged(e: SelectChangedEvent<string>): void {
+  private async handleTypeChanged(
+    e: SelectChangedEvent<string>,
+  ): Promise<void> {
     this.type = parseInt(e.detail.value);
-    this.updateComplete.then(() => this.propertiesRef?.reset());
+    await this.updateComplete;
+    this.propertiesRef?.reset();
   }
 
   private handlePublishedChanged(e: ToggleChangedEvent): void {

--- a/src/components/entity-form/entity-form.ts
+++ b/src/components/entity-form/entity-form.ts
@@ -222,7 +222,9 @@ export class EntityForm extends ViewElement {
           this.type = 0;
         }
 
-        this.propertiesRef?.reset();
+        if (this.propertiesRef) {
+          this.updateComplete.then(() => this.propertiesRef?.reset());
+        }
       },
       {
         fireImmediately: true,
@@ -386,7 +388,7 @@ export class EntityForm extends ViewElement {
 
   private handleTypeChanged(e: SelectChangedEvent<string>): void {
     this.type = parseInt(e.detail.value);
-    this.propertiesRef?.reset();
+    this.updateComplete.then(() => this.propertiesRef?.reset());
   }
 
   private handlePublishedChanged(e: ToggleChangedEvent): void {


### PR DESCRIPTION
## Summary
- Fixes a bug where navigating between list configs on the entity-form-view route caused property fields to render without labels, while keeping the same field count.
- Root cause: a MobX reaction updated `type`/`entityConfig` and synchronously called `propertiesRef.reset()` before Lit flushed the new `entityConfig` down to the child, causing `property-field` to look up its property against a mismatched config and fall back to a labelless default.
- Fix: defer `propertiesRef.reset()` until after `updateComplete` in both the list config reaction and `handleTypeChanged`.

Closes #215

🤖 Generated with [Claude Code](https://claude.ai/code)