### PR TITLE
Link streak cards to a pre-filled chart view

### DIFF
--- a/src/components/chart-builder/chart-builder.ts
+++ b/src/components/chart-builder/chart-builder.ts
@@ -35,6 +35,8 @@ import '@/components/data-point-builder/data-point-builder';
 @customElement('chart-builder')
 export class ChartBuilder extends MobxLitElement {
   @property({ type: Object, attribute: false }) chart?: Chart;
+  @property({ type: Object, attribute: false }) initialConfig?: ChartConfig;
+  @property({ type: String }) initialName = '';
 
   @state() private chartType: ChartConfigType = ChartConfigType.LINE;
   @state() private dataWindowType: DataWindowType = DataWindowType.LAST_30_DAYS;
@@ -54,13 +56,15 @@ export class ChartBuilder extends MobxLitElement {
 
   updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('chart') && this.chart) {
-      this.initFromChart(this.chart);
+      this.initFromConfig(this.chart.config, this.chart.name);
+    } else if (changedProperties.has('initialConfig') && this.initialConfig) {
+      this.initFromConfig(this.initialConfig, this.initialName);
+      void this.handleGenerateChart(false);
     }
   }
 
-  private initFromChart(chart: Chart): void {
-    this.chartName = chart.name;
-    const config = chart.config;
+  private initFromConfig(config: ChartConfig, name = ''): void {
+    this.chartName = name;
     if (config.version === ChartVersion.V2) {
       this.chartType = (config as ChartConfigV2).type as ChartConfigType;
     }

--- a/src/components/streak-card/streak-card.models.ts
+++ b/src/components/streak-card/streak-card.models.ts
@@ -1,4 +1,11 @@
 import { Streak, StreakResult } from 'api-spec/models/Fact';
+import {
+  ChartConfig,
+  ChartConfigType,
+  ChartVersion,
+  DataWindowType,
+  SegmentationType,
+} from 'api-spec/models/Statistic';
 
 import { ControlType } from '@/models/Control';
 import { PropConfigMap, PropTypes } from '@/models/Prop';
@@ -25,3 +32,24 @@ export const streakCardProps: PropConfigMap<StreakCardProps> = {
     control: { type: ControlType.HIDDEN },
   },
 };
+
+export function getStreakChartConfig(streak: Streak): ChartConfig {
+  return {
+    version: ChartVersion.V2,
+    type: ChartConfigType.LINE,
+    dataWindow: { type: DataWindowType.LAST_30_DAYS },
+    segmentation: {
+      type: SegmentationType.TIME,
+      unit: streak.context.segmentUnit,
+    },
+    dataPoints: [streak.context.innerContext],
+  };
+}
+
+export function getStreakChartUrl(streak: Streak): string {
+  const params = new URLSearchParams({
+    config: JSON.stringify(getStreakChartConfig(streak)),
+    name: streak.name,
+  });
+  return `/chart?${params.toString()}`;
+}

--- a/src/components/streak-card/streak-card.ts
+++ b/src/components/streak-card/streak-card.ts
@@ -9,6 +9,7 @@ import {
   StreakCardProp,
   StreakCardProps,
   streakCardProps,
+  getStreakChartUrl,
 } from './streak-card.models';
 
 @customElement('streak-card')
@@ -30,6 +31,7 @@ export class StreakCard extends LitElement {
       border-radius: var(--border-radius, 0.5rem);
       background: var(--box-background-color, #fff);
       color: var(--box-text-color, var(--text-color, inherit));
+      text-decoration: none;
     }
 
     .icon-badge {
@@ -175,7 +177,7 @@ export class StreakCard extends LitElement {
     const isPb = longest > 0 && current === longest;
 
     return html`
-      <div class="card ${isPb ? 'is-pb' : ''}">
+      <a class="card ${isPb ? 'is-pb' : ''}" href=${getStreakChartUrl(streak)}>
         <div class="icon-badge">
           <svg-icon .name=${IconName.FIRE} .size=${22}></svg-icon>
         </div>
@@ -189,7 +191,7 @@ export class StreakCard extends LitElement {
           <span class="stat-label">${translate('pb')}</span>
           <span class="stat-value-pb">${longest}</span>
         </div>
-      </div>
+      </a>
     `;
   }
 }

--- a/src/views/chart-view/chart-view.ts
+++ b/src/views/chart-view/chart-view.ts
@@ -2,7 +2,7 @@ import { html, css, nothing, TemplateResult } from 'lit';
 import { customElement, query, state } from 'lit/decorators.js';
 import type { ChartData } from 'chart.js';
 
-import { ChartConfigType } from 'api-spec/models/Statistic';
+import { ChartConfig, ChartConfigType } from 'api-spec/models/Statistic';
 
 import { translate } from '@/lib/Localization';
 import { ViewElement } from '@/lib/ViewElement';
@@ -31,6 +31,8 @@ export class ChartView extends ViewElement {
   @state() private chartType: `${ChartConfigType}` = ChartConfigType.LINE;
   @state() private hasChart = false;
   @state() private isChartLoading = false;
+  @state() private initialChartConfig: ChartConfig | undefined;
+  @state() private initialChartName = '';
 
   @query('chart-list') private chartList: ChartList | undefined;
 
@@ -45,6 +47,20 @@ export class ChartView extends ViewElement {
       height: 400px;
     }
   `;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    const params = new URLSearchParams(window.location.search);
+    const configParam = params.get('config');
+    if (configParam) {
+      try {
+        this.initialChartConfig = JSON.parse(configParam) as ChartConfig;
+      } catch {
+        this.initialChartConfig = undefined;
+      }
+    }
+    this.initialChartName = params.get('name') ?? '';
+  }
 
   private handleChartBuilt(e: ChartBuiltEvent): void {
     this.isChartLoading = false;
@@ -70,6 +86,8 @@ export class ChartView extends ViewElement {
       <user-header></user-header>
       <div class="view-content">
         <chart-builder
+          .initialConfig=${this.initialChartConfig}
+          initialName=${this.initialChartName}
           @chart-generating=${(_e: ChartGeneratingEvent): void => {
             this.isChartLoading = true;
           }}


### PR DESCRIPTION
## Summary
- The entire streak card is now a link to `/chart`, pre-configured with that streak's fact context as a single data point, encoded via a `config` query parameter.
- `chart-view` reads the `config`/`name` query params and passes them to `chart-builder`, which auto-generates the chart on load.

Closes #202

Generated with [Claude Code](https://claude.ai/code)