### PR TITLE
Move charts above navigation cards on dashboard

### DIFF
--- a/src/components/user-dashboard/user-dashboard.ts
+++ b/src/components/user-dashboard/user-dashboard.ts
@@ -271,8 +271,6 @@ export class UserDashboard extends MobxLitElement {
               </div>
             `
           : nothing}
-        <dashboard-cards .cards=${this.cards}></dashboard-cards>
-
         <div
           class="charts-wrapper ${this.visibleCharts.length > 1
             ? 'scrollable'
@@ -310,6 +308,8 @@ export class UserDashboard extends MobxLitElement {
             )}
           </div>
         </div>
+
+        <dashboard-cards .cards=${this.cards}></dashboard-cards>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

Moves the charts section on the user dashboard to display above the navigation cards instead of below, as requested.

Closes #220

🤖 Generated with [Claude Code](https://claude.ai/code)