### PR TITLE
Improve chart fade effect in user dashboard

### DIFF
--- a/src/components/user-dashboard/user-dashboard.ts
+++ b/src/components/user-dashboard/user-dashboard.ts
@@ -71,13 +71,28 @@ export class UserDashboard extends MobxLitElement {
       margin-top: 1rem;
     }
 
+    .charts-wrapper.scrollable::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: -2rem;
+      bottom: 0;
+      width: 2rem;
+      background: linear-gradient(
+        to left,
+        transparent,
+        var(--background-color, #fff)
+      );
+      pointer-events: none;
+    }
+
     .charts-wrapper.scrollable::after {
       content: '';
       position: absolute;
       top: 0;
-      right: 0;
+      right: -2rem;
       bottom: 0;
-      width: 3rem;
+      width: 2rem;
       background: linear-gradient(
         to right,
         transparent,


### PR DESCRIPTION
## Summary
- Shifted the right-edge fade over the dashboard chart carousel so it lays over the gutter outside the main content width, rather than over the visible chart itself.
- Added a matching fade on the left edge for symmetric easing when swiping charts in/out of view.

Closes #222.

Generated with [Claude Code](https://claude.ai/code)