### PR TITLE
fix: don't auto-create workspace when fetching workspaces fails

### DIFF
--- a/src/components/app-container/app-container.ts
+++ b/src/components/app-container/app-container.ts
@@ -247,12 +247,16 @@ export class AppContainer extends MobxLitElement {
         this.state.authToken
       ) {
         console.time('[orbit] restoreState:fetchConfigs');
+        let workspacesFetchFailed = false;
         const [listConfigs, entityConfigs, settings, workspaces] =
           await Promise.all([
             storage.getListConfigs(),
             storage.getEntityConfigs(),
             storage.getSettings().catch(() => null),
-            storage.getWorkspaces().catch(() => [] as typeof this.state.workspaces),
+            storage.getWorkspaces().catch(() => {
+              workspacesFetchFailed = true;
+              return [] as typeof this.state.workspaces;
+            }),
           ]);
         console.timeEnd('[orbit] restoreState:fetchConfigs');
         console.log(
@@ -270,7 +274,12 @@ export class AppContainer extends MobxLitElement {
           this.state.setSystemSettings(settings.system);
         }
 
-        if (workspaces.length === 0) {
+        if (workspacesFetchFailed) {
+          addToast(
+            translate('failedToLoadWorkspaces'),
+            NotificationType.ERROR,
+          );
+        } else if (workspaces.length === 0) {
           const defaultResult = await storage.createWorkspace(
             translate('workspace'),
             listConfigs.map(c => c.id),


### PR DESCRIPTION
## Summary
- Fixes a bug where a failed API call to fetch workspaces was silently treated as "zero workspaces", causing a new default workspace to be auto-created on every such failure.
- Adds a `workspacesFetchFailed` flag in `app-container.ts`` `restoreState()` so auto-creation only happens when the fetch genuinely succeeds with zero results.
- Shows an error toast (`failedToLoadWorkspaces`) instead of fabricating a workspace when the fetch fails.

Fixes #224

Generated with [Claude Code](https://claude.ai/code)