### PR TITLE
fix: always scroll to top on link navigation, only restore on back/forward

### DIFF
--- a/src/components/app-container/app-container.ts
+++ b/src/components/app-container/app-container.ts
@@ -7,7 +7,7 @@ import { storage } from '@/lib/Storage';
 import { appState } from '@/state';
 import { ViewElement } from '@/lib/ViewElement';
 import { api } from '@/lib/Api';
-import { navigate, setupRouter } from '@/lib/Router';
+import { navigate, routerState, setupRouter } from '@/lib/Router';
 import { themed } from '@/lib/Theme';
 import { Router } from '@/models/Router';
 import { routes } from '@/routes';
@@ -136,7 +136,9 @@ export class AppContainer extends MobxLitElement {
 
     window.addEventListener('view-ready', () => {
       this.state.setViewReady(true);
-      const { x, y } = storage.getWindowScrollPosition();
+      const { x, y } = routerState.isPopState
+        ? storage.getWindowScrollPosition()
+        : { x: 0, y: 0 };
       setTimeout(() => {
         window.scrollTo(x, y);
         setTimeout(() => {

--- a/src/lib/Router.ts
+++ b/src/lib/Router.ts
@@ -4,12 +4,16 @@ import { observable, action } from 'mobx';
 export const routerState: RouterState = observable({
   currentPath: '/',
   params: {},
+  isPopState: false,
 });
 const setCurrentPath = action((path: string) => {
   routerState.currentPath = path;
 });
 const setParams = action((params: Record<string, string>) => {
   routerState.params = params;
+});
+const setIsPopState = action((isPopState: boolean) => {
+  routerState.isPopState = isPopState;
 });
 
 function pathToRegex(path: string): { regex: RegExp; keys: string[] } {
@@ -136,6 +140,7 @@ export function setupRouter(
       (base === '/' ? '' : base.replace(/\/$/, '')) + href,
     );
 
+    setIsPopState(false);
     void renderPath(location.pathname);
   }
 
@@ -165,6 +170,7 @@ export function setupRouter(
   };
 
   const onPop = (): void => {
+    setIsPopState(true);
     void renderPath(location.pathname);
   };
 

--- a/src/models/Router.ts
+++ b/src/models/Router.ts
@@ -14,4 +14,5 @@ export type Router = {
 export type RouterState = {
   currentPath: string;
   params: Record<string, string>;
+  isPopState: boolean;
 };


### PR DESCRIPTION
## Summary
- Navigating to a new view via a link click or programmatic `navigate()` now always resets scroll to the top of the page.
- Scroll position is only restored when the navigation was a browser back/forward (`popstate`), preserving the original intent of the scroll-restoration feature.

## Changes
- `src/models/Router.ts`: added `isPopState` to `RouterState`.
- `src/lib/Router.ts`: track whether the current render was triggered by a `popstate` event vs. a `pushState` navigation.
- `src/components/app-container/app-container.ts`: only restore the saved scroll position on `view-ready` when `routerState.isPopState` is true; otherwise reset to (0, 0).

Fixes #192

Generated with [Claude Code](https://claude.ai/code)