### PR TITLE
Fix: preserve "everything" list selection on reload

### DIFF
--- a/src/components/app-container/app-container.ts
+++ b/src/components/app-container/app-container.ts
@@ -320,7 +320,11 @@ export class AppContainer extends MobxLitElement {
         this.state.setListConfigId(listConfigId);
       }
 
-      if (!this.state.listConfigId && this.state.listConfigs.length) {
+      if (
+        !this.state.listConfigId &&
+        !storage.hasActiveListConfigId() &&
+        this.state.listConfigs.length
+      ) {
         const defaultListConfigId = this.state.getSetting<string>(
           SettingName.DEFAULT_LIST_CONFIG,
         );

--- a/src/lib/Storage.ts
+++ b/src/lib/Storage.ts
@@ -392,6 +392,21 @@ export class Storage implements StorageSchema {
     return listConfigId;
   }
 
+  hasActiveListConfigId(): boolean {
+    try {
+      return (
+        localStorage.getItem(StorageItemKey.ACTIVE_LIST_CONFIG_ID) !== null
+      );
+    } catch (error) {
+      console.error(
+        `Encountered an error while trying to check for a stored active list config ID: ${JSON.stringify(
+          error,
+        )}`,
+      );
+      return false;
+    }
+  }
+
   setAuthToken(authToken: string): void {
     localStorage.setItem(StorageItemKey.AUTH_TOKEN_KEY, authToken);
   }


### PR DESCRIPTION
## Summary

Fixes a bug where reloading the app while on the "everything" list view would:
- rewrite the URL to include a list ID, and
- hide the entity list customizer (filter/sort).

## Root cause

The auto-default-list-selection fallback in `app-container.ts` couldn't distinguish "no list ever chosen" from "everything list explicitly chosen" (persisted as an empty string), since `localStorage.getItem()` returning `''` and `null` were treated identically by `getActiveListConfigId()`.

## Fix

- Added `storage.hasActiveListConfigId()` to distinguish an explicitly-stored empty selection from no selection at all.
- The auto-default fallback now only runs when no active list config ID has ever been stored.

Closes #230

🤖 Generated with [Claude Code](https://claude.ai/code)