### PR TITLE
Show list-filter-preview above filters in entity-list-customizer

### DIFF
--- a/src/components/entity-list-customizer/entity-list-customizer.ts
+++ b/src/components/entity-list-customizer/entity-list-customizer.ts
@@ -13,6 +13,7 @@ import { ListSortUpdatedEvent } from '@/components/list-sort/list-sort.events';
 
 import '@ss/ui/components/ss-collapsable';
 import '@/components/list-filter/list-filter';
+import '@/components/list-filter-preview/list-filter-preview';
 import { themed } from '@/lib/Theme';
 
 const EVERYTHING_FILTER_PANEL_ID = 'everything-filter';
@@ -63,6 +64,9 @@ export class EntityListCustomizer extends MobxLitElement {
 
     return html`
       <div class="enity-list-customizer">
+        <list-filter-preview
+          .listFilter=${this.state.listFilter}
+        ></list-filter-preview>
         <div class="inner">
           <ss-collapsable
             title=${translate('filter')}


### PR DESCRIPTION
## Summary

Renders `list-filter-preview` above the filter/sort controls in `entity-list-customizer`, bound to the active list filter, so users can see what filters are active at a glance on the "everything" list view.

Closes #229

🤖 Generated with [Claude Code](https://claude.ai/code)