### PR TITLE
fix: only show suggested-entity styling before it's published

### DIFF
--- a/src/components/entity-list/entity-list-item/entity-list-item.ts
+++ b/src/components/entity-list/entity-list-item/entity-list-item.ts
@@ -209,7 +209,7 @@ export class EntityListItem extends MobxLitElement {
       full: this.mode === EntityListItemMode.FULL,
       edit: this.mode === EntityListItemMode.EDIT,
       unpublished: !this.published,
-      suggestion: this.suggestion,
+      suggestion: this.suggestion && !this.published,
     };
   }
 
@@ -419,7 +419,7 @@ export class EntityListItem extends MobxLitElement {
         @touchmove=${this.handleTouchMove}
         @touchend=${this.handleTouchEnd}
       >
-        ${this.suggestion
+        ${this.suggestion && !this.published
           ? html`<div class="suggestion-badge">${translate('auto')}</div>`
           : nothing}
         ${this.mode === EntityListItemMode.EDIT


### PR DESCRIPTION
## Summary

The suggested-entity styling (light green background + diagonal "auto" badge) was applied based solely on the `suggested` flag, which remains `true` even after an entity is published. This PR makes both conditions also require the entity to be unpublished, so the special styling disappears once the entity is published.

Closes #235

Generated with [Claude Code](https://claude.ai/code)