### PR TITLE
fix: list filter in 'everything' view not reflecting actual filters

### DIFF
--- a/src/components/entity-list-customizer/entity-list-customizer.ts
+++ b/src/components/entity-list-customizer/entity-list-customizer.ts
@@ -85,6 +85,7 @@ export class EntityListCustomizer extends MobxLitElement {
           >
             <list-filter
               showAll
+              .listFilter=${this.state.listFilter}
               @list-filter-updated=${this.handleFilterUpdated}
             ></list-filter>
           </ss-collapsable>


### PR DESCRIPTION
## Summary
- The `list-filter` panel in `entity-list-customizer` was rendered without a `.listFilter` binding, so it always initialized to its internal defaults (`includeAll: true`, no types) instead of the actual active filter.
- `list-filter-preview` received the real filter and displayed it correctly, which is why the preview text and the editable filter controls disagreed.
- Fix: pass `.listFilter=${this.state.listFilter}` into the `<list-filter>` element, matching the binding already used for the preview.

Fixes #237

## Test plan
- [ ] Open the "Everything" list, apply a filter (e.g. select an entity type), reopen the filter panel, and confirm the panel reflects the applied filter instead of showing defaults.
- [ ] `npm run build` and `npm run lint` pass.

Generated with [Claude Code](https://claude.ai/code)