### PR TITLE
Scroll to top of entity when edit button is clicked

### DIFF
--- a/src/components/entity-list/entity-list-item/entity-list-item.ts
+++ b/src/components/entity-list/entity-list-item/entity-list-item.ts
@@ -251,8 +251,10 @@ export class EntityListItem extends MobxLitElement {
     this.dispatchEvent(new EntitySuggestionAddedEvent({ id: this.entityId }));
   }
 
-  private handleEditRequested(_e: EntityActionBarEditEvent): void {
+  private async handleEditRequested(_e: EntityActionBarEditEvent): Promise<void> {
     this.mode = EntityListItemMode.EDIT;
+    await this.updateComplete;
+    this.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
   private handleDeleteRequested(_e: EntityActionBarDeleteEvent): void {


### PR DESCRIPTION
Fixes #247.

When editing a large entity, the edit form is much shorter than the full display, causing the page to shift and leave the user scrolled past the entity. This smooth-scrolls the entity into view once it switches to edit mode.

Generated with [Claude Code](https://claude.ai/code)