### PR TITLE
fix: prevent image zoom close button from being hidden under top bar

### DIFF
--- a/src/components/entity-list/entity-list-item/entity-list-item-property/entity-list-item-property.ts
+++ b/src/components/entity-list/entity-list-item/entity-list-item-property/entity-list-item-property.ts
@@ -76,7 +76,7 @@ export class EntityListItemProperty extends LitElement {
       position: fixed;
       inset: 0;
       background: rgba(0, 0, 0, 0.85);
-      z-index: 1000;
+      z-index: 6000;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -98,9 +98,9 @@ export class EntityListItemProperty extends LitElement {
     }
 
     .image-zoom-close {
-      position: absolute;
-      top: -2.5rem;
-      right: 0;
+      position: fixed;
+      top: max(1rem, env(safe-area-inset-top));
+      right: 1rem;
       background: none;
       border: none;
       color: #fff;
@@ -175,14 +175,14 @@ export class EntityListItemProperty extends LitElement {
     }
     return html`
       <div class="image-zoom-overlay" @click=${this.closeZoom}>
+        <button
+          class="image-zoom-close"
+          aria-label=${translate('close')}
+          @click=${this.closeZoom}
+        >
+          <svg-close></svg-close>
+        </button>
         <div class="image-zoom-modal" @click=${this.stopPropagation}>
-          <button
-            class="image-zoom-close"
-            aria-label=${translate('close')}
-            @click=${this.closeZoom}
-          >
-            <svg-close></svg-close>
-          </button>
           <img
             src=${this.zoomedImage.src}
             alt=${this.zoomedImage.alt}


### PR DESCRIPTION
## Summary

Fixes the close (X) icon on the image zoom overlay being hidden underneath the app's top bar on mobile.

**Root cause:** The zoom overlay's `z-index: 1000` was lower than the fixed top bar's (`workspace-selector`) `z-index: 2000/5000`, and the close button was positioned above the modal via a negative offset, landing it in the top bar's screen region on small viewports.

**Fix:**
- Raised the overlay's `z-index` to `6000`
- Changed the close button to `position: fixed`, pinned to the viewport (with `env(safe-area-inset-top)` support), and moved it out of the modal's bounds

Closes #246

Generated with [Claude Code](https://claude.ai/code)