### PR TITLE
Fix: trim trailing whitespace on short-text-field blur

### DIFF
--- a/src/components/entity-form/short-text-field/short-text-field.ts
+++ b/src/components/entity-form/short-text-field/short-text-field.ts
@@ -177,14 +177,19 @@ export class ShortTextField extends MobxLitElement {
 
   handleInputBlurred(_: InputChangedEvent): void {
     setTimeout(() => {
+      const trimmedValue = this._value.trimEnd();
+      if (trimmedValue !== this._value) {
+        this.syncValue(trimmedValue);
+      }
+
       if (
         this.propertyConfig.optionsOnly &&
-        this._value.length > 0 &&
-        !this.propertyConfig.options.includes(this._value)
+        trimmedValue.length > 0 &&
+        !this.propertyConfig.options.includes(trimmedValue)
       ) {
         addToast(
           translate('propertyValueNotAllowed', {
-            value: this._value,
+            value: trimmedValue,
             name: this.propertyConfig.name,
           }),
           NotificationType.ERROR,


### PR DESCRIPTION
## Summary
- Fixes a bug where tabbing away from an "options only" short text field after using a mobile keyboard's word-suggestion feature (which appends a trailing space) would fail validation and clear the field's value.
- `handleInputBlurred` in `short-text-field.ts` now trims trailing whitespace from the value before validating, and persists the trimmed value via `syncValue`.

Closes #251

Generated with [Claude Code](https://claude.ai/code)