### PR TITLE
fix: date field saved hours off when left unedited

### DIFF
--- a/src/components/entity-form/entity-form-properties/entity-form-properties.ts
+++ b/src/components/entity-form/entity-form-properties/entity-form-properties.ts
@@ -324,7 +324,7 @@ export class EntityFormProperties extends MobxLitElement {
         let value = property.value;
         if (
           propConfig?.dataType === DataType.DATE &&
-          typeof value === 'number'
+          (typeof value === 'number' || typeof value === 'string')
         ) {
           value = Time.formatDateTime(new Date(value));
         }


### PR DESCRIPTION
## Summary
- Fixes a regression where updating one date field on an entity while leaving another date field untouched caused the untouched field to be saved hours off due to a timezone offset being double-applied.
- Root cause: `setupProperties()` in `entity-form-properties.ts` only converted a loaded date property's raw value to the local `datetime-local` string format when the value was a `number`. When the API returns the value as a string, the raw UTC string was left untouched and resubmitted as-is, causing the server to re-apply the client's timezone offset to an already-UTC value.

## Fix
Widen the type check so both `number` and `string` raw values are normalized to the local datetime string format.

Closes #249

Generated with [Claude Code](https://claude.ai/code)